### PR TITLE
Fix make compile error in expose.cpp(?)

### DIFF
--- a/expose.cpp
+++ b/expose.cpp
@@ -36,8 +36,8 @@ extern "C"
         int devices = inputs.clblast_info%10;
         std::string platformenv = "KCPP_CLBLAST_PLATFORM="+std::to_string(platform);
         std::string deviceenv = "KCPP_CLBLAST_DEVICES="+std::to_string(devices);
-        putenv(platformenv.c_str());
-        putenv(deviceenv.c_str());
+        putenv(const_cast<char*>(platformenv.c_str()));
+        putenv(const_cast<char*>(deviceenv.c_str()));
 
         if(file_format==FileFormat::GPTJ_1 || file_format==FileFormat::GPTJ_2 || file_format==FileFormat::GPTJ_3)
         {

--- a/expose.cpp
+++ b/expose.cpp
@@ -36,8 +36,8 @@ extern "C"
         int devices = inputs.clblast_info%10;
         std::string platformenv = "KCPP_CLBLAST_PLATFORM="+std::to_string(platform);
         std::string deviceenv = "KCPP_CLBLAST_DEVICES="+std::to_string(devices);
-        putenv(const_cast<char*>(platformenv.c_str()));
-        putenv(const_cast<char*>(deviceenv.c_str()));
+        putenv((char*)platformenv.c_str());
+        putenv((char*)deviceenv.c_str());
 
         if(file_format==FileFormat::GPTJ_1 || file_format==FileFormat::GPTJ_2 || file_format==FileFormat::GPTJ_3)
         {


### PR DESCRIPTION
Not sure if this right but currently get this when trying to compile on Linux.
```
expose.cpp: In function ‘bool load_model(load_model_inputs)’:
expose.cpp:39:33: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
   39 |         putenv(platformenv.c_str());
      |                ~~~~~~~~~~~~~~~~~^~
      |                                 |
      |                                 const char*
In file included from /usr/include/c++/12.2.1/cstdlib:75,
                 from /usr/include/c++/12.2.1/ext/string_conversions.h:41,
                 from /usr/include/c++/12.2.1/bits/basic_string.h:3960,
                 from /usr/include/c++/12.2.1/string:53,
                 from /usr/include/c++/12.2.1/bits/locale_classes.h:40,
                 from /usr/include/c++/12.2.1/bits/ios_base.h:41,
                 from /usr/include/c++/12.2.1/ios:42,
                 from /usr/include/c++/12.2.1/istream:38,
                 from /usr/include/c++/12.2.1/fstream:38,
                 from expose.cpp:12:
/usr/include/stdlib.h:667:26: note:   initializing argument 1 of ‘int putenv(char*)’
  667 | extern int putenv (char *__string) __THROW __nonnull ((1));
      |                    ~~~~~~^~~~~~~~
expose.cpp:40:31: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
   40 |         putenv(deviceenv.c_str());
      |                ~~~~~~~~~~~~~~~^~
      |                               |
      |                               const char*
/usr/include/stdlib.h:667:26: note:   initializing argument 1 of ‘int putenv(char*)’
  667 | extern int putenv (char *__string) __THROW __nonnull ((1));
      |                    ~~~~~~^~~~~~~~
make: *** [Makefile:178: expose.o] Error 1
```