### PR TITLE
[README] Improved instructions for building dependent libraries on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ What does it mean? You get llama.cpp with a fancy UI, persistent stories, editin
   - If you want to generate the .exe file, make sure you have the python module PyInstaller installed with pip ('pip install PyInstaller').
   - Run the script make_pyinstaller.bat at a regular terminal (or Windows Explorer).
   - The koboldcpp.exe file will be at your dist folder.
-- If you wish to use your own version of the additional Windows libraries (clblast, libopenblas or OpenCL), you can:
-  - Compile then, or download the lastest release from the respective GitHub repository.
-  - Replace the existing versions of the .dll file located in the project directory root.
-  - Move any import .lib file to the /lib folder of your project, overwriting the older file.
-  - Make the project using the instructions. 
+- If you wish to use your own version of the additional Windows libraries (OpenCL, CLBlast and OpenBLAS), you can do it with:
+  - OpenCL - tested with https://github.com/KhronosGroup/OpenCL-SDK . If you wish to compile it, follow the repository instructions. You will need vcpkg.
+  - CLBlast - tested with https://github.com/CNugteren/CLBlast . If you wish to compile it you will need to reference the OpenCL files. It will only generate the ".lib" file if you compile using MSVC.
+  - OpenBLAS - tested with https://github.com/xianyi/OpenBLAS . 
+  - Move the respectives .lib files to the /lib folder of your project, overwriting the older files.
+  - Make the KoboldCPP project using the instructions above. 
 
 ## OSX and Linux
 - You will have to compile your binaries from source. A makefile is provided, simply run `make`


### PR DESCRIPTION
I encountered difficulties while trying to compile the various Windows libraries that the project depends on. To assist future developers facing the same challenge, I've updated the README with clearer instructions and guidance on building these libraries on Windows systems.

This enhancement includes tips and relevant resource links to make the process more straightforward and accessible for other developers working on the project.