### PR TITLE
Fix format string vulnerability

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -949,9 +949,7 @@ generation_outputs gpttype_generate(const generation_inputs inputs, generation_o
         }
         ::utreplace(tmp, "\n", "\\n");
         outstr += tmp;
-        printf(outstr.c_str());
-
-        printf("\n\n");
+        printf("%s\n\n", outstr.c_str());
     }
 
     while (remaining_tokens > 0)


### PR DESCRIPTION
https://github.com/LostRuins/koboldcpp/blob/b617f2847b5914736ccf65bec22caaf49b39c0a8/gpttype_adapter.cpp#LL952
```
gpttype_adapter.cpp: In function 'generation_outputs gpttype_generate(generation_inputs, generation_outputs&)':
gpttype_adapter.cpp:952:15: error: format not a string literal and no format arguments [-Werror=format-security]
  952 |         printf(outstr.c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~
```