### PR TITLE
Add ability to set lora-base file

### DIFF
--- a/expose.cpp
+++ b/expose.cpp
@@ -22,6 +22,7 @@
 
 std::string executable_path = "";
 std::string lora_filename = "";
+std::string lora_base_filename = "";
 
 extern "C"
 {
@@ -35,6 +36,7 @@ extern "C"
     {
         std::string model = inputs.model_filename;
         lora_filename = inputs.lora_filename;
+        lora_base_filename = inputs.lora_base_filename;
 
         int forceversion = inputs.forceversion;
 

--- a/expose.h
+++ b/expose.h
@@ -11,6 +11,7 @@ struct load_model_inputs
     const char * executable_path;
     const char * model_filename;
     const char * lora_filename;
+    const char * lora_base_filename;
     const bool use_mmap;
     const bool use_mlock;
     const bool use_smartcontext;
@@ -48,3 +49,4 @@ struct generation_outputs
 
 extern std::string executable_path;
 extern std::string lora_filename;
+extern std::string lora_base_filename;

--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -334,9 +334,15 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
         {
             printf("\nAttempting to apply LORA adapter: %s\n", lora_filename.c_str());
 
+            const char * lora_base_arg = NULL;
+            if (lora_base_filename != "") {
+                printf("Using LORA base model: %s\n", lora_base_filename.c_str());
+                lora_base_arg = lora_base_filename.c_str();
+            }
+
             int err = llama_v2_apply_lora_from_file(llama_ctx_v2,
                                                  lora_filename.c_str(),
-                                                 NULL,
+                                                 lora_base_arg,
                                                  n_threads);
             if (err != 0)
             {
@@ -373,9 +379,15 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
         {
             printf("\nAttempting to apply LORA adapter: %s\n", lora_filename.c_str());
 
+            const char * lora_base_arg = NULL;
+            if (lora_base_filename != "") {
+                printf("Using LORA base model: %s\n", lora_base_filename.c_str());
+                lora_base_arg = lora_base_filename.c_str();
+            }
+
             int err = llama_apply_lora_from_file(llama_ctx_v3,
                                                  lora_filename.c_str(),
-                                                 NULL,
+                                                 lora_base_arg,
                                                  n_threads);
             if (err != 0)
             {

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -18,6 +18,7 @@ class load_model_inputs(ctypes.Structure):
                 ("executable_path", ctypes.c_char_p),
                 ("model_filename", ctypes.c_char_p),
                 ("lora_filename", ctypes.c_char_p),
+                ("lora_base_filename", ctypes.c_char_p),
                 ("use_mmap", ctypes.c_bool),
                 ("use_mlock", ctypes.c_bool),
                 ("use_smartcontext", ctypes.c_bool),
@@ -139,6 +140,7 @@ def load_model(model_filename):
     inputs = load_model_inputs()
     inputs.model_filename = model_filename.encode("UTF-8")
     inputs.lora_filename = args.lora.encode("UTF-8")
+    inputs.lora_base_filename = args.lora_base.encode("UTF-8")
     inputs.batch_size = 8
     inputs.max_context_length = maxctx #initial value to use for ctx, can be overwritten
     inputs.threads = args.threads
@@ -647,6 +649,14 @@ def main(args):
         else:
             args.lora = os.path.abspath(args.lora)
 
+    if args.lora_base and args.lora_base!="":
+        if not os.path.exists(args.lora_base):
+            print(f"Cannot find lora base file: {args.lora_base}")
+            time.sleep(2)
+            sys.exit(2)
+        else:
+            args.lora_base = os.path.abspath(args.lora_base)
+
     if args.psutil_set_threads:
         import psutil
         args.threads = psutil.cpu_count(logical=False)
@@ -703,6 +713,7 @@ if __name__ == '__main__':
     parser.add_argument("--host", help="Host IP to listen on. If empty, all routable interfaces are accepted.", default="")
     parser.add_argument("--launch", help="Launches a web browser when load is completed.", action='store_true')
     parser.add_argument("--lora", help="LLAMA models only, applies a lora file on top of model. Experimental.", default="")
+    parser.add_argument("--lora-base", help="Optional model to use as a base for the layers modified by the LoRA adapter. Experimental.", default="")
     physical_core_limit = 1
     if os.cpu_count()!=None and os.cpu_count()>1:
         physical_core_limit = int(os.cpu_count()/2)


### PR DESCRIPTION
Used the same argument as llama.cpp (`--lora-base`). I have tested this with `GGJT_3` files (using Llama 30B q4_0 with f16 as the lora-base).