### PR TITLE
Fixed random seed feature

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -186,7 +186,7 @@ def load_model(model_filename):
     ret = handle.load_model(inputs)
     return ret
 
-def generate(prompt,max_length=20, max_context_length=512,temperature=0.8,top_k=120, top_a=0.0 ,top_p=0.85, typical_p=1.0, tfs=1.0 ,rep_pen=1.1,rep_pen_range=128,seed=-1,stop_sequence=[],stream_sse=False):
+def generate(prompt,max_length=20, max_context_length=512,temperature=0.8,top_k=120, top_a=0.0 ,top_p=0.85, typical_p=1.0, tfs=1.0 ,rep_pen=1.1,rep_pen_range=128,seed=0,stop_sequence=[],stream_sse=False):
     inputs = generation_inputs()
     outputs = ctypes.create_unicode_buffer(ctypes.sizeof(generation_outputs))
     inputs.prompt = prompt.encode("UTF-8")
@@ -272,7 +272,7 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
                     tfs=genparams.get('tfs', 1.0),
                     rep_pen=genparams.get('rep_pen', 1.1),
                     rep_pen_range=genparams.get('rep_pen_range', 128),
-                    seed=genparams.get('sampler_seed', -1),
+                    seed=genparams.get('sampler_seed',0),
                     stop_sequence=genparams.get('stop_sequence', []),
                     stream_sse=stream_flag)
 
@@ -288,7 +288,7 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
                     tfs=genparams.get('tfs', 1.0),
                     rep_pen=genparams.get('rep_pen', 1.1),
                     rep_pen_range=genparams.get('rep_pen_range', 128),
-                    seed=genparams.get('sampler_seed', -1),
+                    seed=genparams.get('sampler_seed', 0),
                     stop_sequence=genparams.get('stop_sequence', []),
                     stream_sse=stream_flag)
 


### PR DESCRIPTION
Random seeds are currently broken and multiple generations always return the same tokens, this PR fixes the feature again. Upstream llama.cpp commit b8c8dda changed seed variable to unsigned. Adjusted magic value for random seed from -1 to 0 to match upstream changes.