### PR TITLE
Fix: don't send headers twice when streaming

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -572,12 +572,14 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
                 newprompt = fullprompt
 
                 gen = asyncio.run(self.handle_request(genparams, newprompt, basic_api_flag, kai_sse_stream_flag))
-                try:
-                    self.send_response(200)
-                    self.end_headers()
-                    self.wfile.write(json.dumps(gen).encode())
-                except:
-                    print("Generate: The response could not be sent, maybe connection was terminated?")
+
+                if not kai_sse_stream_flag:
+                    try:
+                        self.send_response(200)
+                        self.end_headers()
+                        self.wfile.write(json.dumps(gen).encode())
+                    except:
+                        print("Generate: The response could not be sent, maybe connection was terminated?")
 
                 return
         finally:

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -573,11 +573,13 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
 
                 gen = asyncio.run(self.handle_request(genparams, newprompt, basic_api_flag, kai_sse_stream_flag))
 
-                if not kai_sse_stream_flag:
-                    try:
+                try:
+                    # Headers are already sent when streaming
+                    if not kai_sse_stream_flag:
                         self.send_response(200)
                         self.end_headers()
-                        self.wfile.write(json.dumps(gen).encode())
+
+                    self.wfile.write(json.dumps(gen).encode())
                     except:
                         print("Generate: The response could not be sent, maybe connection was terminated?")
 


### PR DESCRIPTION
Fixes #357.

When streaming is used, the headers are sent twice (once in `handle_sse_stream`, once in `do_POST`), which might cause the second batch of headers to be flushed into a subsequent request, causing JSON parsing errors. This occurs especially when the request was aborted (which is SillyTavern's behaviour.)

Since the headers are already sent in `handle_sse_stream`, we'll simply not send them in `do_POST`.