### PR TITLE
Streaming performance improvements

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -428,7 +428,7 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         incomplete_token_buffer = bytearray()
         while not handle.has_finished():
-            if current_token < handle.get_stream_count():
+            while current_token < handle.get_stream_count():
                 token = handle.new_token(current_token)
 
                 if token is None: # Token isnt ready yet, received nullpointer
@@ -445,7 +445,7 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
                     event_str = json.dumps(event_data)
                     await self.send_sse_event("message", event_str)
 
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.1)
 
         # flush buffers, sleep a bit to make sure all data sent, and then force close the connection
         self.wfile.flush()


### PR DESCRIPTION
"You don't have to be constantly checking for new tokens, it performs much better to wait a bit and do them in bulk, otherwise the SSE handle task wastes a bunch of time doing nothing
this fix seems to bring streaming performance in line with non streaming performance on my machine. Too lazy to pr, someone show it to them"

Not my fix, this was created by a /lmg/ user, seemed important though