### PR TITLE
API link shown for colab users

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1754,6 +1754,17 @@ def main(launch_args,start_server=True):
 
     if start_server:
         print(f"Please connect to custom endpoint at {epurl}")
+
+        # Check if nohup.out exists and retrieve the quick tunnel link if so; for Google Colab users
+        if os.path.exists("nohup.out"):
+            with open("nohup.out", "r") as file:
+                lines = file.readlines()
+                for i, line in enumerate(lines):
+                    if "Your quick Tunnel has been created!" in line and i+1 < len(lines):
+                        retrieved_link = lines[i+1].split("|")[1].strip()
+                        print("\nKobold API Link:", retrieved_link, "\n")
+                        break
+
         asyncio.run(RunServerMultiThreaded(args.host, args.port, embedded_kailite))
     else:
         print(f"Server was not started, main function complete. Idling.")

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1753,11 +1753,11 @@ def main(launch_args,start_server=True):
         horde_thread.start()
 
     if start_server:
-        if not os.path.exists("/content/koboldcpp/"): # Print statement for users outside of Google Colab
+        if not os.path.exists("/content/koboldcpp/nohup.out"): # Print statement for users outside of Google Colab
             print(f"Please connect to custom endpoint at {epurl}")
         else:  # Google Colab print statements
             print(f"Local host (not the Public Link): {epurl}")
-            with open("nohup.out", "r") as file:
+            with open("/content/koboldcpp/nohup.out", "r") as file:
                 lines = file.readlines()
                 for i, line in enumerate(lines):
                     if "Your quick Tunnel has been created!" in line and i+1 < len(lines):

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1753,10 +1753,10 @@ def main(launch_args,start_server=True):
         horde_thread.start()
 
     if start_server:
-        print(f"Please connect to custom endpoint at {epurl}")
-
-        # Check if nohup.out exists and retrieve the quick tunnel link if so; for Google Colab users
-        if os.path.exists("nohup.out"):
+        if not os.path.exists("/content/koboldcpp/"): # Print statement for users outside of Google Colab
+            print(f"Please connect to custom endpoint at {epurl}")
+        else:  # Google Colab print statements
+            print(f"Local host (not the Public Link): {epurl}")
             with open("nohup.out", "r") as file:
                 lines = file.readlines()
                 for i, line in enumerate(lines):


### PR DESCRIPTION
Should work for both the official colab and my custom forked one; they share the logging system