### PR TITLE
avoid leaving a zombie process for --onready

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1951,7 +1951,7 @@ def main(launch_args,start_server=True):
         def onready_subprocess():
             import subprocess
             print("Starting Post-Load subprocess...")
-            subprocess.Popen(args.onready[0], shell=True)
+            subprocess.run(args.onready[0], shell=True)
         timer_thread = threading.Timer(1, onready_subprocess) #1 second delay
         timer_thread.start()
 


### PR DESCRIPTION
subprocess.Popen() needs to be either used with `with:` or have `.wait()` called or be destroyed using `del` – otherwise the child process stays as a zombie process after exiting, until the object is GC'd.

subprocess.run() does the necessary .wait() automatically. (It's a convenience wrapper available from Python 3.6.)

Since shell=True is used and none of the subprocess-specific features are used, it might be even simpler to use `os.system()` (available everywhere).