### PR TITLE
OpenAI compat API adapter

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -414,36 +414,32 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
                 messages_array = genparams.get('messages', [])
                 adapter_obj = genparams.get('adapter', {})
                 messages_string = ""
-                templates = adapter_obj.get("templates", {})
-                templates_system = templates.get("system", {})
-                templates_user = templates.get("user", {})
-                templates_assistant = templates.get("assistant", {})
-                system_message_start = templates_system.get("start") or "\n### Instruction:\n"
-                system_message_end = templates_system.get("end") or ""
-                user_message_start = templates_user.get("start") or "\n### Instruction:\n"
-                user_message_end = templates_user.get("end") or ""
-                assistant_message_start = templates_assistant.get("start") or "\n### Response:\n"
-                assistant_message_end = templates_assistant.get("end") or ""
-                after_last_message = templates.get("after_last_message") or ""        
+                system_message_start = adapter_obj.get("system_start", "\n### Instruction:\n")
+                system_message_end = adapter_obj.get("system_end", "")
+                user_message_start = adapter_obj.get("user_start", "\n### Instruction:\n")
+                user_message_end = adapter_obj.get("user_end", "")
+                assistant_message_start = adapter_obj.get("assistant_start", "\n### Response:\n")
+                assistant_message_end = adapter_obj.get("assistant_end", "")
 
                 for message in messages_array:
                     if message['role'] == "system":
-                        messages_string+=system_message_start
+                        messages_string += system_message_start
                     elif message['role'] == "user":
-                        messages_string+=user_message_start
+                        messages_string += user_message_start
                     elif message['role'] == "assistant":
-                        messages_string+=assistant_message_start
-                    messages_string+=message['content']
-                    if message['role'] == "system":
-                        messages_string+=system_message_end
-                    elif message['role'] == "user":
-                        messages_string+=user_message_end
-                    elif message['role'] == "assistant":
-                        messages_string+=assistant_message_end
+                        messages_string += assistant_message_start
 
-                messages_string += after_last_message
-                messages_string = messages_string.rstrip()
-                
+                    messages_string += message['content']
+
+                    if message['role'] == "system":
+                        messages_string += system_message_end
+                    elif message['role'] == "user":
+                        messages_string += user_message_end
+                    elif message['role'] == "assistant":
+                        messages_string += assistant_message_end
+
+                messages_string += assistant_message_start
+
                 genparams["prompt"] = messages_string
                 frqp = genparams.get('frequency_penalty', 0.1)
                 scaled_rep_pen = genparams.get('presence_penalty', frqp) + 1


### PR DESCRIPTION
The current OpenAI-like API uses hardcoded chat templates. This PR implements a non-breaking adapter users can exploit to use models requiring various chat templates. Testing request against [Mistral7B Doplhin](https://huggingface.co/TheBloke/dolphin-2.0-mistral-7B-GGUF):

```json
{
    "temperature": 0.5,
    "max_tokens": 1024,
    "messages": [
        {
            "role": "system",
            "content": "You roleplay as a dungeon master engaged in a session of Dungeons and Dragons with the user. Write in an immersive way to avoid spoiling the user's experience."
        },
        {
            "role": "user",
            "content": "I am a kobold named Nico, what should I do?"
        }
    ],
    "adapter": {
        "templates": {
          "system": {
              "start": "<|im_start|>system\n",
              "end": "<|im_end|>\n"
          },
          "user": {
              "start": "<|im_start|>user\n",
              "end": "<|im_end|>\n"
          },
          "assistent": {
              "start": "",
              "end": ""
          },
          "after_last_message": ""
        }
    }
}
```

This PR proposes the following non-breaking addition to `/v1/chat/completions` endpoint:

```diff
+"adapter": {
+        "templates": {
+        "system": {
+            "start": " String | None,
+            "end": String | None
+        },
+        "user": {
+            "start": String | None,
+            "end": String | None
+        },
+        "assistent": {
+            "start": String | None,
+            "end": String | None
+        },
+        "after_last_message": String | None
+        }
+    }
```

If users omit the `adapter` object in the request, we fall back to the default Vicuna-style template.

Response with this patch:
![image](https://github.com/LostRuins/koboldcpp/assets/10260230/401720e2-23f9-4932-a0d1-3878dd275df4)


Response with stock 1.46.1 build:
![image](https://github.com/LostRuins/koboldcpp/assets/10260230/83513af1-9fe3-494e-b750-0d20b2c3b42f)
