### PR TITLE
Fix for Top K disabling

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -1304,7 +1304,7 @@ generation_outputs gpttype_generate(const generation_inputs inputs, generation_o
     }
     if (params.top_k < 1)
     {
-        params.top_k = 120; //to disable top_k we actually need to increase this value to a very high number
+        params.top_k = 32000; // typical vocabulary size of llama to ensure top K can be disabled
     }
     if (params.seed <= 0 || params.seed==0xFFFFFFFF)
     {

--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -1304,7 +1304,7 @@ generation_outputs gpttype_generate(const generation_inputs inputs, generation_o
     }
     if (params.top_k < 1)
     {
-        params.top_k = 32000; // typical vocabulary size of llama to ensure top K can be disabled
+        params.top_k = n_vocab; // all tokens in the vocabulary should be considered if top k is disabled
     }
     if (params.seed <= 0 || params.seed==0xFFFFFFFF)
     {


### PR DESCRIPTION
The Top K is being forced to 120 when 'disabled' for all models, even when the value is set to zero. This means you effectively disable Top K unless Mirostat is turned on. This is a problem for reproducability reasons. It might also affect other samplers like Tail Free Sampling from working as intended as they come later in the sampler stack.
The fix for this is as simple as setting the value to the current model's vocabulary size.