### PR TITLE
Add context size as a configurable parameter for colab notebook

### DIFF
--- a/colab.ipynb
+++ b/colab.ipynb
@@ -21,6 +21,7 @@
         "\r\n",
         "Model = \"https://huggingface.co/TheBloke/Airoboros-L2-13B-2.2-GGUF/resolve/main/airoboros-l2-13b-2.2.Q4_K_M.gguf\" #@param [\"\"]{allow-input: true}\r\n",
         "Layers = 43 #@param [43]{allow-input: true}\r\n",
+		"ContextSize = 4096 #@param [4096] {allow-input: true}\r\n",
         "\r\n",
         "%cd /content\r\n",
         "!git clone https://github.com/LostRuins/koboldcpp\r\n",
@@ -33,7 +34,7 @@
         "!nohup ./cloudflared-linux-amd64 tunnel --url http://localhost:5001 &\r\n",
         "!sleep 10\r\n",
         "!cat nohup.out\r\n",
-        "!python koboldcpp.py model.ggml --usecublas 0 mmq --gpulayers $Layers\r\n"
+        "!python koboldcpp.py model.ggml --usecublas 0 mmq --gpulayers $Layers --contextsize $ContextSize\r\n"
       ]
     }
   ],


### PR DESCRIPTION
This can be done by knowledgeable users by just editing the notebook in the !python line but since otherwise the colab notebook makes it so easy for beginners, adding the context size parameter as an easy to see and configure option seems to make sense.