### PR TITLE
Add context size parameter to google colab notebook

### DIFF
--- a/colab.ipynb
+++ b/colab.ipynb
@@ -44,6 +44,7 @@
         "\r\n",
         "Model = \"https://huggingface.co/KoboldAI/LLaMA2-13B-Tiefighter-GGUF/resolve/main/LLaMA2-13B-Tiefighter.Q4_K_S.gguf\" #@param [\"\"]{allow-input: true}\r\n",
         "Layers = 43 #@param [43]{allow-input: true}\r\n",
+        "ContextSize = 4096 #@param [4096] {allow-input: true}\r\n",
         "\r\n",
         "%cd /content\r\n",
         "!git clone https://github.com/LostRuins/koboldcpp\r\n",
@@ -61,7 +62,7 @@
         "!nohup ./cloudflared-linux-amd64 tunnel --url http://localhost:5001 &\r\n",
         "!sleep 8\r\n",
         "!cat nohup.out\r\n",
-        "!python koboldcpp.py model.ggml --usecublas 0 mmq --multiuser --gpulayers $Layers --hordeconfig concedo 1 1 --onready \"echo Connect to the link below && cat nohup.out | grep trycloudflare.com\"\r\n"
+        "!python koboldcpp.py model.ggml --usecublas 0 mmq --multiuser --gpulayers $Layers --contextsize $ContextSize --hordeconfig concedo 1 1 --onready \"echo Connect to the link below && cat nohup.out | grep trycloudflare.com\"\r\n"
       ]
     }
   ],


### PR DESCRIPTION
-add configurable context size to parameters along with models and layers for ease of use

-this can already be done with a simple edit by experienced llm users but new users may not know this is a parameter they should set.