### PR TITLE
koboldcpp.sh - The Mamba Multitool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,8 @@ hipblas.dll
 koboldcpp_hipblas.so
 koboldcpp_hipblas.dll
 
+bin/
+conda/
+
 # Jetbrains idea folder
 .idea/

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,11 +1,12 @@
 name: koboldcpp
 channels:
-  - nvidia/label/cuda-11.8.0
+  - nvidia/label/cuda-11.5.0
   - conda-forge
   - defaults
 dependencies:
-  - cuda-nvcc=11.8
-  - cuda-libraries-dev=11.8
+  - python=3.8
+  - cuda-nvcc=11.5
+  - cuda-libraries-dev=11.5
   - cxx-compiler
   - gxx=10
   - pip

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,6 +18,7 @@ dependencies:
   - make
   - packaging
   - pyinstaller
+  - libcblas
   - ocl-icd-system
   - pip:
     - customtkinter

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,5 +16,6 @@ dependencies:
   - ninja
   - make
   - packaging
+  - pocl
   - pip:
     - customtkinter

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,6 +16,7 @@ dependencies:
   - ninja
   - make
   - packaging
+  - pyinstaller
   - pocl
   - pip:
     - customtkinter

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,20 @@
+name: koboldcpp
+channels:
+  - nvidia/label/cuda-11.8.0
+  - conda-forge
+  - defaults
+dependencies:
+  - cuda-nvcc=11.8
+  - cuda-libraries-dev=11.8
+  - cxx-compiler
+  - gxx=10
+  - pip
+  - git=2.35.1
+  - libopenblas
+  - openblas
+  - clblast
+  - ninja
+  - make
+  - packaging
+  - pip:
+    - customtkinter

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,6 +18,6 @@ dependencies:
   - make
   - packaging
   - pyinstaller
-  - pocl
+  - ocl-icd-system
   - pip:
     - customtkinter

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -14,7 +14,7 @@ bin/micromamba run -r conda -n linux make LLAMA_OPENBLAS=1 LLAMA_CLBLAST=1 LLAMA
 if [[ $1 == "rebuild" ]]; then
 	echo Rebuild complete, you can now try to launch Koboldcpp.
 elif [[ $1 == "dist" ]]; then
-	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --add-data='./klite.embd:.' --add-data='./kcpp_docs.embd:.' --clean --console koboldcpp.py -n "koboldcpp.bin"
+	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --add-data='./klite.embd:.' --add-data='./kcpp_docs.embd:.' --add-data='./rwkv_vocab.embd:.' --add-data='./rwkv_world_vocab.embd:.' --clean --console koboldcpp.py -n "koboldcpp.bin"
 else
 	bin/micromamba run -r conda -n linux python koboldcpp.py $*
 fi

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
-wget -qO- https://anaconda.org/conda-forge/micromamba/1.5.3/download/linux-64/micromamba-1.5.3-0.tar.bz2 | tar -xvj bin/micromamba
-if [[ ! -f "conda/envs/linux/bin/python" || $1 == "rebuild" ]]; then
- bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
- bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
- bin/micromamba run -r conda -n linux make clean
+if [ ! -f "bin/micromamba" ]; then
+	wget -qO- https://anaconda.org/conda-forge/micromamba/1.5.3/download/linux-64/micromamba-1.5.3-0.tar.bz2 | tar -xvj bin/micromamba
 fi
+
+if [[ ! -f "conda/envs/linux/bin/python" || $1 == "rebuild" ]]; then
+	bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
+	bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
+	bin/micromamba run -r conda -n linux make clean
+fi
+
 bin/micromamba run -r conda -n linux make LLAMA_OPENBLAS=1 LLAMA_CLBLAST=1 LLAMA_CUBLAS=1 LLAMA_PORTABLE=1
-bin/micromamba run -r conda -n linux python koboldcpp.py $*
+
+if [[ $1 == "rebuild" ]]; then
+	echo Rebuild complete, you can now try to launch Koboldcpp.
+else
+	bin/micromamba run -r conda -n linux python koboldcpp.py $*
+fi

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -14,7 +14,9 @@ bin/micromamba run -r conda -n linux make LLAMA_OPENBLAS=1 LLAMA_CLBLAST=1 LLAMA
 if [[ $1 == "rebuild" ]]; then
 	echo Rebuild complete, you can now try to launch Koboldcpp.
 elif [[ $1 == "dist" ]]; then
+	bin/micromamba remove -r conda -n linux --force ocl-icd -y
 	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --add-data='./klite.embd:.' --add-data='./kcpp_docs.embd:.' --add-data='./rwkv_vocab.embd:.' --add-data='./rwkv_world_vocab.embd:.' --clean --console koboldcpp.py -n "koboldcpp-linux-x64"
-else
+	bin/micromamba install -r conda -n linux ocl-icd -c conda-forge -y
+ else
 	bin/micromamba run -r conda -n linux python koboldcpp.py $*
 fi

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+wget -qO- https://anaconda.org/conda-forge/micromamba/1.5.3/download/linux-64/micromamba-1.5.3-0.tar.bz2 | tar -xvj bin/micromamba
+if [[ ! -f "conda/envs/linux/bin/python" || $1 == "rebuild" ]]; then
+ bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
+ bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
+ bin/micromamba run -r conda -n linux make clean
+fi
+bin/micromamba run -r conda -n linux make LLAMA_OPENBLAS=1 LLAMA_CLBLAST=1 LLAMA_CUBLAS=1 LLAMA_PORTABLE=1
+bin/micromamba run -r conda -n linux python koboldcpp.py $*

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ ! -f "bin/micromamba" ]; then
-	wget -qO- https://anaconda.org/conda-forge/micromamba/1.5.3/download/linux-64/micromamba-1.5.3-0.tar.bz2 | tar -xvj bin/micromamba
+	curl -Ls https://anaconda.org/conda-forge/micromamba/1.5.3/download/linux-64/micromamba-1.5.3-0.tar.bz2 | tar -xvj bin/micromamba
 fi
 
 if [[ ! -f "conda/envs/linux/bin/python" || $1 == "rebuild" ]]; then

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -13,6 +13,8 @@ bin/micromamba run -r conda -n linux make LLAMA_OPENBLAS=1 LLAMA_CLBLAST=1 LLAMA
 
 if [[ $1 == "rebuild" ]]; then
 	echo Rebuild complete, you can now try to launch Koboldcpp.
+elif [[ $1 == "dist" ]]; then
+	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --clean --console koboldcpp.py -n "koboldcpp.bin"
 else
 	bin/micromamba run -r conda -n linux python koboldcpp.py $*
 fi

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -14,7 +14,7 @@ bin/micromamba run -r conda -n linux make LLAMA_OPENBLAS=1 LLAMA_CLBLAST=1 LLAMA
 if [[ $1 == "rebuild" ]]; then
 	echo Rebuild complete, you can now try to launch Koboldcpp.
 elif [[ $1 == "dist" ]]; then
-	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --clean --console koboldcpp.py -n "koboldcpp.bin"
+	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --add-data='./klite.embd:.' --add-data='./kcpp_docs.embd:.' --clean --console koboldcpp.py -n "koboldcpp.bin"
 else
 	bin/micromamba run -r conda -n linux python koboldcpp.py $*
 fi

--- a/koboldcpp.sh
+++ b/koboldcpp.sh
@@ -14,7 +14,7 @@ bin/micromamba run -r conda -n linux make LLAMA_OPENBLAS=1 LLAMA_CLBLAST=1 LLAMA
 if [[ $1 == "rebuild" ]]; then
 	echo Rebuild complete, you can now try to launch Koboldcpp.
 elif [[ $1 == "dist" ]]; then
-	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --add-data='./klite.embd:.' --add-data='./kcpp_docs.embd:.' --add-data='./rwkv_vocab.embd:.' --add-data='./rwkv_world_vocab.embd:.' --clean --console koboldcpp.py -n "koboldcpp.bin"
+	bin/micromamba run -r conda -n linux pyinstaller --noconfirm --onefile --collect-all customtkinter --add-data='./koboldcpp_default.so:.' --add-data='./koboldcpp_cublas.so:.' --add-data='./koboldcpp_openblas.so:.' --add-data='./koboldcpp_clblast.so:.' --add-data='./koboldcpp_clblast_noavx2.so:.' --add-data='./klite.embd:.' --add-data='./kcpp_docs.embd:.' --add-data='./rwkv_vocab.embd:.' --add-data='./rwkv_world_vocab.embd:.' --clean --console koboldcpp.py -n "koboldcpp-linux-x64"
 else
 	bin/micromamba run -r conda -n linux python koboldcpp.py $*
 fi


### PR DESCRIPTION
Something I am very excited to add, my specialty MicroMamba runtime now for Koboldcpp!

This makes it much simpler for Linux users to get going, complete with 3 modes.
Mode 1: koboldcpp.sh as a substitute for koboldcpp.py, it will ensure all the dependencies are installed (You do need wget, and bzip2 for it to function), automatically compiles all the libs and then launches koboldcpp with its own internal python.
Mode 2: koboldcpp.sh dist : This automatically generates an experimental pyinstaller build, These seem to work across a wide range of Linux distributions if compiled on Ubuntu 18.04 (See my releases). If a user has an incompatible distro chances are it does work if they run the command themselves to generate a binary for their libs.
Mode 3: koboldcpp.sh rebuild : This triggers a recompile as well as an update of the runtime, useful after modifications or git pull's.