### PR TITLE
Handle broken pipe errors during streaming

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -621,7 +621,7 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
             await asyncio.gather(*tasks)
             generate_result = generate_task.result()
             return generate_result
-        except ConnectionAbortedError as cae: # attempt to abort if connection lost
+        except (BrokenPipeError, ConnectionAbortedError) as cae: # attempt to abort if connection lost
             print(cae)
             handle.abort_generate()
             time.sleep(0.1) #short delay


### PR DESCRIPTION
Hello, I have the same problem as reported in #568 (while using /api/extra/generate/stream). The easiest way to reproduce this behavior is by starting a streaming connection and then simply dropping it, for example
```bash
timeout 2s curl --request POST \
  --url http:/localhost:5001/api/extra/generate/stream \
  --header 'Content-Type: application/json' \
  --data '{ "prompt": "Niko the kobold stalked carefully down the alley, his small scaly figure obscured by a dusky cloak that fluttered lightly in the cold winter breeze." }'
```
Starting a new connection will then cause a crash.

One way to fix this is by handling BrokenPipeError. There is already a code for handling ConnectionAbortedError and I have tried to trigger it (without explicitly closing connection on a client) but failed. It's not entirely clear to me what is the difference between the two, however handling BrokenPipeError in the same way as ConnectionAbortedError does fix the problem.