### PR TITLE
CUDA 11.4 for Github CI

### DIFF
--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -17,8 +17,8 @@ jobs:
       - uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit
         with:
-          cuda: '11.5.0'
-          method: 'network'
+          cuda: '11.4.4'
+          method: 'local'
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
 
       - name: Build

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Clone
         id: checkout

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -12,7 +12,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo_experimental
+          ref: concedo
 
       - uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -18,9 +18,7 @@ jobs:
         id: cuda-toolkit
         with:
           cuda: '11.4.4'
-          method: 'local'
-          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
-
+        
       - name: Build
         id: cmake_build
         run: |

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit
         with:
-          cuda: '11.4.4'
+          cuda: '11.5.0'
           method: 'network'
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
 

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -12,7 +12,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo
+          ref: concedo_experimental
 
       - uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit
         with:
-          cuda: '11.7.1'
+          cuda: '11.4.4'
           method: 'network'
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
 

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DLLAMA_CUBLAS=ON
+          cmake .. -DLLAMA_CUBLAS=ON -DCMAKE_SYSTEM_VERSION="10.0.19041.0"
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
 
       - name: Save artifact


### PR DESCRIPTION
This PR downgrades CUDA to 11.4 to be in line with our previous releases, this results in a smaller binary and K80 compatibility.