### PR TITLE
Fix Android build by fixing your preprocessor guards

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -1998,7 +1998,7 @@ inline static void ggml_critical_section_end(void) {
 }
 
 // Android's libc implementation "bionic" does not support setting affinity
-#ifdef __linux__ && !defined(__BIONIC__)
+#if defined(__linux__) && !defined(__BIONIC__)
 static cpu_set_t ggml_get_numa_affinity(void) {
     cpu_set_t cpuset;
     pthread_t thread;

--- a/ggml.c
+++ b/ggml.c
@@ -1997,7 +1997,8 @@ inline static void ggml_critical_section_end(void) {
     atomic_fetch_sub(&g_state_barrier, 1);
 }
 
-#ifdef __linux__
+// Android's libc implementation "bionic" does not support setting affinity
+#ifdef __linux__ && !defined(__BIONIC__)
 static cpu_set_t ggml_get_numa_affinity(void) {
     cpu_set_t cpuset;
     pthread_t thread;

--- a/ggml.c
+++ b/ggml.c
@@ -2020,7 +2020,8 @@ void ggml_numa_init(enum ggml_numa_strategy numa_flag) {
         return;
     }
 
-#ifdef __linux__
+// Android's libc implementation "bionic" does not support setting affinity
+#if defined(__linux__) && !defined(__BIONIC__)
     struct stat st;
     char path[256];
     int rv;


### PR DESCRIPTION
I noticed that the latest version doesn't compile on android/termux.

It said something about affinity**_np**() not being available and it looks like you already knew this and put the respective preprocessor guards around the relevant code, but simply missed these ones.

Thanks!