### PR TITLE
Resolve Metal compilation errors for sdcpp

### DIFF
--- a/otherarch/sdcpp/stable-diffusion.cpp
+++ b/otherarch/sdcpp/stable-diffusion.cpp
@@ -124,7 +124,7 @@ public:
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_metal_log_set_callback(ggml_log_callback_default, nullptr);
+        ggml_backend_metal_log_set_callback(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 

--- a/otherarch/sdcpp/upscaler.cpp
+++ b/otherarch/sdcpp/upscaler.cpp
@@ -21,7 +21,7 @@ struct UpscalerGGML {
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_metal_log_set_callback(ggml_log_callback_default, nullptr);
+        ggml_backend_metal_log_set_callback(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 


### PR DESCRIPTION
Resolves following compilation errors on macOS with LLAMA_METAL=1

```
In file included from otherarch/sdcpp/sdtype_adapter.cpp:11:
./otherarch/sdcpp/stable-diffusion.cpp:127:9: error: use of undeclared identifier 'ggml_metal_log_set_callback'; did you mean 'ggml_backend_metal_log_set_callback'?
        ggml_metal_log_set_callback(ggml_log_callback_default, nullptr);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
        ggml_backend_metal_log_set_callback
./ggml-metal.h:43:15: note: 'ggml_backend_metal_log_set_callback' declared here
GGML_API void ggml_backend_metal_log_set_callback(ggml_log_callback log_callback, void * user_data);
              ^
In file included from otherarch/sdcpp/sdtype_adapter.cpp:13:
./otherarch/sdcpp/upscaler.cpp:24:9: error: use of undeclared identifier 'ggml_metal_log_set_callback'; did you mean 'ggml_backend_metal_log_set_callback'?
        ggml_metal_log_set_callback(ggml_log_callback_default, nullptr);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
        ggml_backend_metal_log_set_callback
./ggml-metal.h:43:15: note: 'ggml_backend_metal_log_set_callback' declared here
GGML_API void ggml_backend_metal_log_set_callback(ggml_log_callback log_callback, void * user_data);
              ^
otherarch/sdcpp/sdtype_adapter.cpp:190:28: warning: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Wstring-compare]
    if(inputs.sample_method=="euler a") //all lowercase
                           ^ ~~~~~~~~~
8 warnings and 2 errors generated.
make: *** [sdcpp_default.o] Error 1
make: *** Waiting for unfinished jobs....
```