### PR TITLE
Set launcher file dialog initial paths from existing file values if they exist

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1499,7 +1499,9 @@ def show_new_gui():
     def makefileentry(parent, text, searchtext, var, row=0, width=200, filetypes=[], onchoosefile=None, singlerow=False, tooltiptxt=""):
         makelabel(parent, text, row,0,tooltiptxt)
         def getfilename(var, text):
-            fnam = askopenfilename(title=text,filetypes=filetypes)
+            initialDir = os.path.dirname(var.get()) 
+            initialDir = initialDir if os.path.isdir(initialDir) else os.getcwd()
+            fnam = askopenfilename(title=text,filetypes=filetypes, initialdir=initialDir)
             if fnam:
                 var.set(fnam)
                 if onchoosefile:
@@ -2151,7 +2153,7 @@ def show_new_gui():
         file_type = [("KoboldCpp Settings", "*.kcpps")]
         global runmode_untouched
         runmode_untouched = False
-        filename = askopenfilename(filetypes=file_type, defaultextension=file_type)
+        filename = askopenfilename(filetypes=file_type, defaultextension=file_type, initialdir=os.getcwd())
         if not filename or filename=="":
             return
         with open(filename, 'r') as f:


### PR DESCRIPTION
### Motivation

I was having trouble finding which of my `.safetensors` checkpoints for Stable Diffusion would actually work rather than fail to load. Since I was having to reload and try a different file a lot, I found it inconvenient to always navigate to the path where I keep those checkpoint files whenever I reloaded. Especially when my `.kcpps` was already pointing at a file in the correct directory, albeit at a file that didn't work.

This changes it so the 'Browse' buttons for files in the launcher will use the path from the current value (if there is one) to start the file dialog in. This also smooths out swapping LLM models when you already have a `.kcpps` file to tweak.

### Changes

- In the launcher, if an existing value is set for a file value (e.g. Model), use that file's directory as the initial directory when the file dialog is opened for the value with 'Browse'.
- In the launcher explicitly always set the initial directory for 'Load' to cwd.

### Possible Problems/Concerns

- I'm assuming you want PRs to 'concedo-experimental' rather than 'concedo'.
- I haven't tried building an .exe and testing that with these changes, as I'm on Linux atm.