### PR TITLE
Stop forcing concedo_experimental in CI

### DIFF
--- a/.github/workflows/kcpp-build-release-linux-cuda12.yaml
+++ b/.github/workflows/kcpp-build-release-linux-cuda12.yaml
@@ -13,7 +13,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo_experimental
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Dependencies
         id: depends

--- a/.github/workflows/kcpp-build-release-linux.yaml
+++ b/.github/workflows/kcpp-build-release-linux.yaml
@@ -12,7 +12,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo_experimental
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Dependencies
         id: depends

--- a/.github/workflows/kcpp-build-release-win-cuda.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda.yaml
@@ -12,7 +12,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo_experimental
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit

--- a/.github/workflows/kcpp-build-release-win-cuda12.yaml
+++ b/.github/workflows/kcpp-build-release-win-cuda12.yaml
@@ -12,7 +12,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo_experimental
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit

--- a/.github/workflows/kcpp-build-release-win-full-cu12.yaml
+++ b/.github/workflows/kcpp-build-release-win-full-cu12.yaml
@@ -12,7 +12,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo_experimental
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Get Python
         uses: actions/setup-python@v2

--- a/.github/workflows/kcpp-build-release-win-full.yaml
+++ b/.github/workflows/kcpp-build-release-win-full.yaml
@@ -12,7 +12,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
-          ref: concedo_experimental
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Get Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
This PR adjust the CI so we can build the builds we actually intend to build, devs are otherwise accidentally getting experimental which caused me to give out the wrong version and someone else could not use actions at all in his git.