### PR TITLE
Resolve compilation error of sdtype_adapter.cpp on macOS

### DIFF
--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -160,7 +160,7 @@ bool sdtype_load_model(const sd_load_model_inputs inputs) {
     if(inputs.taesd)
     {
         taesdpath = executable_path + "taesd.embd";
-        printf("With TAE SD VAE: %s\n",taesdpath);
+        printf("With TAE SD VAE: %s\n",taesdpath.c_str());
     }
     else if(inputs.vae_filename!="")
     {


### PR DESCRIPTION
Resolves following compilation error:
```
otherarch/sdcpp/sdtype_adapter.cpp:163:40: error: cannot pass non-trivial object of type 'std::string' (aka 'basic_string<char>') to variadic function; expected type from format string was 'char *' [-Wnon-pod-varargs]
        printf("With TAE SD VAE: %s\n",taesdpath);
                                 ~~    ^~~~~~~~~
```