### PR TITLE
hide API key when blurred

### DIFF
--- a/klite.embd
+++ b/klite.embd
@@ -6980,7 +6980,8 @@ Current version: 138
 
 	var onInputboxOk = null;
 	var onInputboxCancel = null;
-	function inputBox(text,title,inputVal,inputPlaceholder,onDone,isHtml=false,isTextArea=false)
+	// Note: `isPassword` is ignored when `isTextArea` is true
+	function inputBox(text,title,inputVal,inputPlaceholder,onDone,isHtml=false,isTextArea=false,isPassword=false)
 	{
 		if (!text) { text = ""; }
 		if (!title) { title = "User Input"; }
@@ -7005,6 +7006,11 @@ Current version: 138
 			document.getElementById("inputboxcontainerinputarea").classList.add("hidden");
 			document.getElementById("inputboxcontainerinput").value = inputVal;
 			document.getElementById("inputboxcontainerinput").placeholder = escapeHtml(inputPlaceholder);
+			if(isPassword)
+			{
+				document.getElementById("inputboxcontainerinput").onfocus = function () { this.type = "text"; }
+				document.getElementById("inputboxcontainerinput").onblur = function () { this.type = "password"; }
+			}
 		}
 
 		onInputboxOk = function(){document.getElementById("inputboxcontainer").classList.add("hidden");onDone();};
@@ -7573,7 +7579,7 @@ Current version: 138
 												if (userinput != null && userinput!="") {
 													custom_kobold_key = document.getElementById("customkoboldkey").value = localmodekey = localsettings.saved_kai_key = userinput.trim();
 												}
-											},false);
+											},false, false, true);
 										}
 
 									}else{


### PR DESCRIPTION
Hi!

This is a quick hack to implement a fix for #851. It adds an `isPassword` parameter to `inputBox`; when it loses focus, it changes itself to a password field hiding the input. It is similar to the current implementation of `focus_api_keys` and `hide_api_keys`.

I'm sorry, but this is my first time working on the codebase, and I may be missing something. Thanks!