### PR TITLE
Update expose.h - Compile error

### DIFF
--- a/expose.h
+++ b/expose.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #pragma once
 
 const int stop_token_max = 16;


### PR DESCRIPTION
Fixes compile issues on Windows with w64devkit

```
In file included from ./model_adapter.h:14,
                 from otherarch/whispercpp/whisper_adapter.cpp:1:
./expose.h:29:5: error: 'int32_t' does not name a type
   29 |     int32_t token_id;
      |     ^~~~~~~
./expose.h:1:1: note: 'int32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint '
  +++ |+#include <cstdint>
    1 | #pragma once
```