### PR TITLE
Add Phi-3 Mini instruct tag preset to Lite

### DIFF
--- a/klite.embd
+++ b/klite.embd
@@ -9084,6 +9084,10 @@ Current version: 145
 				st = "<|eot_id|><|start_header_id|>user<|end_header_id|>\\n\\n";
 				et = "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\\n\\n";
 				break;
+            case "10": // Phi-3 Mini
+                st = "<|user|>\\n";
+                et = "<|end|>\\n<|assistant|>";
+                break;
 			default:
 				break;
 		}
@@ -16016,6 +16020,7 @@ Current version: 145
 								<option value="7">KoboldAI Format</option>
 								<option value="8">CommandR</option>
 								<option value="9">Llama 3 Chat</option>
+                                <option value="10">Phi-3 Mini</option>
 							</select>
 							<div class="settingsmall miniinput" style="width:100%;padding:2px">
 							<div class="justifyleft settingsmall">Sys. Prompt <span class="helpicon">?<span class="helptext">A system pre-prompt sent at the very start to guide the AI behavior. Usually NOT needed.</span></span></div>


### PR DESCRIPTION
Hello!
This is my first time contributing to a public Git repo. Apologies if I'm not doing this right.

This PR simply adds an instruct tag preset for the [Microsoft Phi-3 Mini](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf) model, accessible through the dropdown menu in Kobold Lite. The same preset will also work for most models in the Phi-3 family.

Phi-3 is a pretty high performance model for its size, and it can run well on lower end systems (4.46T/s on GTX 780 3GB!). A GGUF file is also readily available from Microsoft.

I've tested this PR, and it doesn't spit out garbage.

![Kobold-Phi-PR](https://github.com/LostRuins/koboldcpp/assets/63884317/18879a74-9ef4-49c3-9a7a-dec243cf2dce)

With the ever-growing selection of LLMs being made available to the general public, the current instruct tag preset system should probably be replaced with a more flexible preset menu, where users can save their own presets. A big, updated catalogue of instruct presets for various models would also make Kobold much easier to use, and people wouldn't need to track down the proper prompt templates for each model.

Unfortunately, that's far out of scope for my programming capabilities. I just thought I'd suggest it.

Thanks a lot for taking the time to check out my PR! I suppose if anyone wants to suggest tag presets to add, I can follow this up with another pull request.