### PR TITLE
Check for keyanti before accessing it

### DIFF
--- a/klite.embd
+++ b/klite.embd
@@ -5546,7 +5546,7 @@ Current version: 145
 							let nwi = {
 								"key": itm.key[0],
 								"keysecondary": (itm.keysecondary.length > 0 ? itm.keysecondary[0] : ""),
-								"keyanti": (itm.keyanti.length > 0 ? itm.keyanti[0] : ""),
+								"keyanti": (itm.keyanti && itm.keyanti.length > 0 ? itm.keyanti[0] : ""),
 								"content": itm.content,
 								"comment": itm.comment,
 								"folder": null,


### PR DESCRIPTION
Adding anti worldinfo keys seems to have resulted in all old stories failing to load because their WI entries didn't have the `keyanti` property, and we try to access its `length` when loading it.