### PR TITLE
Give the CI builds a recognizable AVX1 name

### DIFF
--- a/.github/workflows/kcpp-build-release-win-noavx2-full.yaml
+++ b/.github/workflows/kcpp-build-release-win-noavx2-full.yaml
@@ -1,4 +1,4 @@
-name: Koboldcpp Windows Full Binaries
+name: Koboldcpp Windows Full AVX1 Binaries
 
 on: workflow_dispatch
 env:


### PR DESCRIPTION
Very simple commit that makes the AVX1 builds distinct in the Actions list