### PR TITLE
Add Cuda Graphs in CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(LLAMA_CUDA_F16                        "llama: use 16 bit floats for dmmv 
 set(LLAMA_CUDA_KQUANTS_ITER "2" CACHE STRING "llama: iters./thread per block for Q2_K/Q6_K")
 set(LLAMA_CUDA_PEER_MAX_BATCH_SIZE "128" CACHE STRING
                                              "llama: max. batch size for using peer access")
+set(GGML_CUDA_USE_GRAPHS                                                                        ON)
 option(LLAMA_HIPBLAS                         "llama: use hipBLAS"                               OFF)
 
 # Other


### PR DESCRIPTION
Added by Slaren on LCPP after the recent refactor of LCPP.

https://github.com/ggerganov/llama.cpp/pull/8140

It must be for something (even if I saw the graphs in the KCPP logs already), so this PR allows to benefit from it now (or disable it!).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
