### PR TITLE
Resolve `make: *** No rule to make target `ggml-metal.m', needed by `…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ ifdef LLAMA_METAL
 	LDFLAGS  += -framework Foundation -framework Metal -framework MetalKit -framework MetalPerformanceShaders
 	OBJS     += ggml-metal.o
 
-ggml-metal.o: ggml-metal.m ggml-metal.h
+ggml-metal.o: ggml/src/ggml-metal.m ggml/include/ggml-metal.h
 	@echo "== Preparing merged Metal file =="
 	@sed -e '/#include "ggml-common.h"/r ggml/src/ggml-common.h' -e '/#include "ggml-common.h"/d' < ggml/src/ggml-metal.metal > ggml/src/ggml-metal-merged.metal
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
Resolve ```make: *** No rule to make target `ggml-metal.m', needed by `ggml-metal.o'.  Stop.``` on macOS Metal when executing `LLAMA_METAL=1 make`.

Tested on M1 Max and works well.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
