### PR TITLE
Update kcpp_adapters

### DIFF
--- a/kcpp_adapters/Alpaca.json
+++ b/kcpp_adapters/Alpaca.json
@@ -1,0 +1,8 @@
+{
+  "system_start": "",
+  "system_end": "\n\n",
+  "user_start": "### Instruction:\n",
+  "user_end": "\n\n",
+  "assistant_start": "### Response:\n",
+  "assistant_end": "</s>\n\n"
+}

--- a/kcpp_adapters/ChatML.json
+++ b/kcpp_adapters/ChatML.json
@@ -1,8 +1,8 @@
 {
-"system_start":"<|im_start|>system\n",
-"system_end":"<|im_end|>",
-"user_start":"<|im_start|>user\n",
-"user_end":"<|im_end|>",
-"assistant_start":"<|im_start|>assistant\n",
-"assistant_end":"<|im_end|>"
+  "system_start": "<|im_start|>system\n",
+  "system_end": "<|im_end|>\n",
+  "user_start": "<|im_start|>user\n",
+  "user_end": "<|im_end|>\n",
+  "assistant_start": "<|im_start|>assistant\n",
+  "assistant_end": "<|im_end|>\n"
 }

--- a/kcpp_adapters/Command-R.json
+++ b/kcpp_adapters/Command-R.json
@@ -1,8 +1,8 @@
 {
-"system_start":"<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
-"system_end":"<|END_OF_TURN_TOKEN|>",
-"user_start":"<|START_OF_TURN_TOKEN|><|USER_TOKEN|>",
-"user_end":"<|END_OF_TURN_TOKEN|>",
-"assistant_start":"<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",
-"assistant_end":"<|END_OF_TURN_TOKEN|>"
+  "system_start": "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
+  "system_end": "<|END_OF_TURN_TOKEN|>",
+  "user_start": "<|START_OF_TURN_TOKEN|><|USER_TOKEN|>",
+  "user_end": "<|END_OF_TURN_TOKEN|>",
+  "assistant_start": "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",
+  "assistant_end": "<|END_OF_TURN_TOKEN|>"
 }

--- a/kcpp_adapters/Gemma-2.json
+++ b/kcpp_adapters/Gemma-2.json
@@ -1,8 +1,8 @@
 {
-"system_start":"<start_of_turn>system\n",
-"system_end":"<end_of_turn>",
-"user_start":"<start_of_turn>user\n",
-"user_end":"<end_of_turn>",
-"assistant_start":"<start_of_turn>model\n",
-"assistant_end":"<end_of_turn>"
+  "system_start": "<start_of_turn>system\n",
+  "system_end": "<end_of_turn>\n",
+  "user_start": "<start_of_turn>user\n",
+  "user_end": "<end_of_turn>\n",
+  "assistant_start": "<start_of_turn>model\n",
+  "assistant_end": "<end_of_turn>\n"
 }

--- a/kcpp_adapters/Llama-2-Chat.json
+++ b/kcpp_adapters/Llama-2-Chat.json
@@ -1,8 +1,8 @@
 {
-"system_start":"",
-"system_end":"",
-"user_start":"[INST] ",
-"user_end":"",
-"assistant_start":" [/INST]",
-"assistant_end":""
+  "system_start": "",
+  "system_end": "",
+  "user_start": "<s>[INST] ",
+  "user_end": "",
+  "assistant_start": " [/INST] ",
+  "assistant_end": " </s>\n"
 }

--- a/kcpp_adapters/Llama-3.json
+++ b/kcpp_adapters/Llama-3.json
@@ -1,8 +1,8 @@
 {
-"system_start":"<|start_header_id|>system<|end_header_id|>\n\n",
-"system_end":"<|eot_id|>",
-"user_start":"<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n",
-"user_end":"<|eot_id|>",
-"assistant_start":"<|start_header_id|>assistant<|end_header_id|>\n\n",
-"assistant_end":"<|eot_id|>"
+  "system_start": "<|start_header_id|>system<|end_header_id|>\n\n",
+  "system_end": "<|eot_id|>",
+  "user_start": "<|start_header_id|>user<|end_header_id|>\n\n",
+  "user_end": "<|eot_id|>",
+  "assistant_start": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+  "assistant_end": "<|eot_id|>"
 }

--- a/kcpp_adapters/Metharme.json
+++ b/kcpp_adapters/Metharme.json
@@ -1,8 +1,8 @@
 {
-"system_start":"<|system|>",
-"system_end":"",
-"user_start":"<|user|>",
-"user_end":"",
-"assistant_start":"<|model>",
-"assistant_end":""
+  "system_start": "<|system|>",
+  "system_end": "",
+  "user_start": "<|user|>",
+  "user_end": "",
+  "assistant_start": "<|model>",
+  "assistant_end": ""
 }

--- a/kcpp_adapters/Mistral.json
+++ b/kcpp_adapters/Mistral.json
@@ -1,8 +1,8 @@
 {
-"system_start":"",
-"system_end":"",
-"user_start":"[INST] ",
-"user_end":" [/INST]\n",
-"assistant_start":"",
-"assistant_end":"\n"
+  "system_start": "",
+  "system_end": "",
+  "user_start": "[INST] ",
+  "user_end": "",
+  "assistant_start": " [/INST]",
+  "assistant_end": "</s> "
 }

--- a/kcpp_adapters/Phi-3.json
+++ b/kcpp_adapters/Phi-3.json
@@ -1,8 +1,8 @@
 {
-"system_start":"<|system|>",
-"system_end":"<|end|>",
-"user_start":"<|user|>",
-"user_end":"<|end|>",
-"assistant_start":"<|assistant|>",
-"assistant_end":"<|end|>"
+  "system_start": "<|system|>\n",
+  "system_end": "<|end|>\n",
+  "user_start": "<|user|>\n",
+  "user_end": "<|end|>\n",
+  "assistant_start": "<|assistant|>\n",
+  "assistant_end": "<|end|>\n"
 }

--- a/kcpp_adapters/Vicuna.json
+++ b/kcpp_adapters/Vicuna.json
@@ -1,8 +1,8 @@
 {
   "system_start": "",
-  "system_end": "\n",
-  "user_start": "\nUSER: ",
-  "user_end": "",
-  "assistant_start": "\nASSISTANT: ",
-  "assistant_end": "</s>"
+  "system_end": "\n\n",
+  "user_start": "USER: ",
+  "user_end": "\n",
+  "assistant_start": "ASSISTANT: ",
+  "assistant_end": "</s>\n"
 }

--- a/kcpp_adapters/Vicuna.json
+++ b/kcpp_adapters/Vicuna.json
@@ -1,8 +1,8 @@
 {
-"system_start":"\nSYSTEM: ",
-"system_end":"",
-"user_start":"\nUSER: ",
-"user_end":"",
-"assistant_start":"\nASSISTANT: ",
-"assistant_end":""
+  "system_start": "",
+  "system_end": "\n",
+  "user_start": "\nUSER: ",
+  "user_end": "",
+  "assistant_start": "\nASSISTANT: ",
+  "assistant_end": "</s>"
 }


### PR DESCRIPTION
1. Reformatted the JSONs.
2. [ChatML](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/chat-markup-language#working-with-chat-markup-language-chatml)
    - Added a `\n` to `system_end`, `user_end`, and `assistant_end`.
3. [Gemma-2 Instruct](https://ai.google.dev/gemma/docs/formatting#formatting-instruction)
    - Added a `\n` to `system_end`, `user_end`, and `assistant_end`.
    - [The official instruct models weren't trained with system turn support](https://ai.google.dev/gemma/docs/formatting#system-instructions), but we should still keep this here for anyone who fine-tunes support in since this'll likely be the way it done.
4. [LLaMa-2 Chat](https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-2/)
    - Added a BOS token to `user_start`. This'll mean the first turn will have double BOS since one is automatically added, but all turns after are more correct to the training.
    - Added a space to `assistant_start`.
    - Added a space, EOS token, and `\n` to `assistant_end`.
    - I don't know how the system turn could be added, but LLaMa-2-Chat *does* support one.
5. [LLaMa-3 Instruct](https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3)
    - Removed the EOT token from `user_start`.
6. [Mistral Instruct](https://huggingface.co/docs/transformers/main/en/chat_templating)
    - Moved the assistant string from `user_end` to `assistant_start`.
    - Removed the `\n` from `assistant_start`.
    - Removed the `\n` from `assistant_end`
    - Added an EOS token and space to `assistant_end`.
7. [Phi-3 Instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct#chat-format)
    - Added a `\n` to `system_start`, `system_end`, `user_start`, `user_end`, `assistant_start`, and `assistant_end`.
8. [Vicuna](https://github.com/lm-sys/FastChat/blob/main/docs/vicuna_weights_version.md#example-prompt-weights-v11-v13-v15)
    - Removed the `\nSYSTEM:` from `system_start`.
    - Removed `\n` from `user_start`.
    - Removed `\n` from `assistant_start`.
    - Added `\n\n` to `system_end`.
    - Added `\n` to `user_end`.
    - Added `\n` to `assistant_end`.
    - Added an EOS token to `assistant_end`.
9. [Alpaca](https://github.com/tatsu-lab/stanford_alpaca)
    - Added an adapter for it. I'm not 100% if the original model which introduced the format added an EOS token after each assistant turn, but I do know that axolotl does when training so I added it here.