### PR TITLE
New automatic layers

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -616,7 +616,7 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                     headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
                     ratio = mem/(fsize*csmul*1.5)
                     if headcount > 0:
-                        ratio = max(ratio, mem - (1.0*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize*1.1 + (layers*headcount*headkvlen*cs*4))
+                        ratio = max(ratio, mem - (1.0*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize + (layers*headcount*headkvlen*cs*4))
                     layerlimit = int(ratio*layers)
             else:
                 ggufmeta = read_gguf_metadata(filepath)

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -617,7 +617,7 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                     ratio = mem/(fsize*csmul*1.5)
                     print(ratio)
                     if headcount > 0:
-                        ratio = max(ratio,mem/(fsize*1.1 + (layers*headcount*headkvlen*cs*4) + (layers*4*headkvlen*cs*4) + (1.5*1024*1024*1024)))
+                        ratio = (mem - (1.0*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize*1.1 + (layers*headcount*headkvlen*cs*4))
                         print(ratio)
                     layerlimit = int(ratio*layers)
             else:

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -615,8 +615,10 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                     headcount = ggufmeta[1]
                     headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
                     ratio = mem/(fsize*csmul*1.5)
+                    print(ratio)
                     if headcount > 0:
-                        ratio = max(ratio,mem/(fsize*1.025 + (layers*headcount*headkvlen*cs*4) + (layers*4*headkvlen*cs*4) + (1.5*1024*1024*1024)))
+                        ratio = max(ratio,mem/(fsize*1.1 + (layers*headcount*headkvlen*cs*4) + (layers*4*headkvlen*cs*4) + (1.5*1024*1024*1024)))
+                        print(ratio)
                     layerlimit = int(ratio*layers)
             else:
                 layerlimit = 200 # assume full offload

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -616,7 +616,7 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                     headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
                     ratio = mem/(fsize*csmul*1.5)
                     if headcount > 0:
-                        ratio = max(ratio,mem/(fsize*1.34 + (layers*headcount*headkvlen*cs*4.25)))
+                        ratio = max(ratio,mem/(fsize*1.025 + (layers*headcount*headkvlen*cs*4) + (layers*4*headkvlen*cs*4) + (1.5*1024*1024*1024)))
                     layerlimit = int(ratio*layers)
             else:
                 layerlimit = 200 # assume full offload

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -616,7 +616,7 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                     headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
                     ratio = mem/(fsize*csmul*1.5)
                     if headcount > 0:
-                        ratio = max(ratio, mem - (1.0*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize + (layers*headcount*headkvlen*cs*4))
+                        ratio = max(ratio, mem - (1.5*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize + (layers*headcount*headkvlen*cs*4))
                     layerlimit = int(ratio*layers)
             else:
                 ggufmeta = read_gguf_metadata(filepath)

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -617,7 +617,7 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                     ratio = mem/(fsize*csmul*1.5)
                     if headcount > 0:
                         ratio = max(ratio, mem - (1.5*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize + (layers*headcount*headkvlen*cs*4))
-                    layerlimit = int(ratio*layers)
+                    layerlimit = min(int(ratio*layers), (layers + 3))
             else:
                 ggufmeta = read_gguf_metadata(filepath)
                 if not ggufmeta or ggufmeta[0]==0: #fail to read or no layers

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -605,25 +605,18 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                 csmul = 1.2
             elif cs and cs > 2048:
                 csmul = 1.1
-            if mem < fsize*1.6*csmul:
-                ggufmeta = read_gguf_metadata(filepath)
-                if not ggufmeta or ggufmeta[0]==0: #fail to read or no layers
-                    sizeperlayer = fsize*csmul*0.052
-                    layerlimit = int(min(200,mem/sizeperlayer))
-                else:
-                    layers = ggufmeta[0]
-                    headcount = ggufmeta[1]
-                    headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
-                    ratio = mem/(fsize*csmul*1.5)
-                    if headcount > 0:
-                        ratio = max(ratio, mem - (1.5*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize + (layers*headcount*headkvlen*cs*4))
-                    layerlimit = min(int(ratio*layers), (layers + 3))
+            ggufmeta = read_gguf_metadata(filepath)
+            if not ggufmeta or ggufmeta[0]==0: #fail to read or no layers
+                sizeperlayer = fsize*csmul*0.052
+                layerlimit = int(min(200,mem/sizeperlayer))
             else:
-                ggufmeta = read_gguf_metadata(filepath)
-                if not ggufmeta or ggufmeta[0]==0: #fail to read or no layers
-                    layerlimit = 200 # assume full offload
-                else:
-                    layerlimit = ggufmeta[0] + 3
+                layers = ggufmeta[0]
+                headcount = ggufmeta[1]
+                headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
+                ratio = mem/(fsize*csmul*1.5)
+                if headcount > 0:
+                    ratio = max(ratio, mem - (1.5*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize + (layers*headcount*headkvlen*cs*4))
+                layerlimit = min(int(ratio*layers), (layers + 3))
         return layerlimit
     except Exception as ex:
         return 0

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -614,8 +614,11 @@ def autoset_gpu_layers(filepath,ctxsize,gpumem): #shitty algo to determine how m
                 headcount = ggufmeta[1]
                 headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
                 ratio = mem/(fsize*csmul*1.5)
+                computemem = layers*4*headkvlen*cs*4*1.25 # For now the first 4 is the hardcoded result for a blasbatchsize of 512. Ideally we automatically calculate blasbatchsize / 4 but I couldn't easily grab the value yet - Henk
+                contextmem = layers*headcount*headkvlen*cs*4
+                reservedmem = 1.5*1024*1024*1024 # Users often don't have their GPU's VRAM worth of memory, we assume 500MB to avoid driver swapping + 500MB for the OS + 500MB for background apps / browser - Henk
                 if headcount > 0:
-                    ratio = max(ratio, mem - (1.5*1024*1024*1024) - (layers*4*headkvlen*cs*4*1.25))/(fsize + (layers*headcount*headkvlen*cs*4))
+                    ratio = max(ratio, (mem - reservedmem - computemem) / (fsize + contextmem))
                 layerlimit = min(int(ratio*layers), (layers + 3))
         return layerlimit
     except Exception as ex:


### PR DESCRIPTION
This is the work between me and Pyro, PR contains the current iteration of the new algorithm which is very close to someones maximum layer count but still slightly conservative. We can possibly get rid of the fsize 1.1 as lower is likely to work especially at larger file sizes.

I also polished the safe 200 layer value, for now I didn't overhaul this entire logic because of the legacy models but if 200 layers is going to be put it will first see if it can get a more accurate number from the GGUF and if so do layers + 3. This allows the user to have a more realistic feel for how big that model is. I know that in more modern models this is 1 extra layer instead of 3, but I wanted to keep edge cases in mind since i know originally it was a +3.

Update: Currently without fsize 1.1 as it appears that its no longer needed. On a 6GB GPU it gets 1 layer of tiefighter more which puts it at 18 which is within the safe margin. 

Update 2: Since I expect a sizable amount of people to have background tasks over 1GB I restored the 500MB extra since the fsize bloat no longer takes care of this now.