### PR TITLE
on linux, link against Openblas Parallel (e.g. for fedora 40)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ else
 	endif
 
 	ifdef LLAMA_OPENBLAS
-	OPENBLAS_BUILD = $(CXX) $(CXXFLAGS) $^ $(ARCH_ADD) -lopenblas -shared -o $@.so $(LDFLAGS)
+	OPENBLAS_BUILD = $(CXX) $(CXXFLAGS) $^ $(ARCH_ADD) -lopenblasp -shared -o $@.so $(LDFLAGS)
 	endif
 	ifdef LLAMA_CLBLAST
 		ifeq ($(UNAME_S),Darwin)

--- a/ggml/src/ggml-blas.cpp
+++ b/ggml/src/ggml-blas.cpp
@@ -352,6 +352,15 @@ ggml_backend_t ggml_backend_blas_init(void) {
     fprintf(stderr, "%s: warning: ggml is using OpenMP, but BLIS was compiled without OpenMP support\n", __func__);
 #endif
 
+    fprintf(stderr, "%s: openblas_get_parallel %d \n", __func__, openblas_get_parallel());
+    fprintf(stderr, "%s: openblas_get_config %s \n", __func__, openblas_get_config());
+
+#ifdef GGML_USE_OPENMP
+    fprintf(stderr, "%s: GGML_USE_OPENMP %s \n", __func__, GGML_USE_OPENMP);
+#else
+    fprintf(stderr, "%s: GGML_USE_OPENMP n/a \n", __func__);
+#endif
+
     return backend;
 }
 


### PR DESCRIPTION
on recent linux distros (e.g. fedora 40), 
the paralell version of openblas has a "p" suffix "-lopenblas**p**",
therefore linking against "-lopenblas" always uses the serial version.

in addition, 
we print out at runtime the exact flavour of openblas used:

```
ggml_backend_blas_init: openblas_get_parallel 1 
ggml_backend_blas_init: openblas_get_config OpenBLAS 0.3.26 DYNAMIC_ARCH NO_AFFINITY Haswell MAX_THREADS=128 
ggml_backend_blas_init: GGML_USE_OPENMP n/a 
```
