### PR TITLE
Update Llama-3.json

### DIFF
--- a/kcpp_adapters/Llama-3.json
+++ b/kcpp_adapters/Llama-3.json
@@ -1,8 +1,8 @@
 {
-  "system_start": "<|start_header_id|>system<|end_header_id|>\n\n",
-  "system_end": "<|eot_id|>",
-  "user_start": "<|start_header_id|>user<|end_header_id|>\n\n",
-  "user_end": "<|eot_id|>",
-  "assistant_start": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+  "system_start": "<|start_header_id|>system<|end_header_id|>\n",
+  "system_end": "<|eot_id|>\n",
+  "user_start": "<|start_header_id|>user<|end_header_id|>\n",
+  "user_end": "<|eot_id|>\n",
+  "assistant_start": "<|start_header_id|>assistant<|end_header_id|>\n",
   "assistant_end": "<|eot_id|>"
 }


### PR DESCRIPTION
Probably doesn't matter too much, but Llama 3 doesn't have the extra newlines while llama 3.1 does.  Also, added appropriate newlines.

Will send the one for Llama 3.1 and 3.2 next.