### PR TITLE
Make token bans work in SillyTavern

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -912,6 +912,11 @@ def generate(genparams, is_quiet=False, stream_flag=False):
     banned_strings = genparams.get('banned_strings', []) # SillyTavern uses that name
     banned_tokens = genparams.get('banned_tokens', banned_strings)
     bypass_eos_token = genparams.get('bypass_eos', False)
+    custom_token_bans = genparams.get('custom_token_bans', '')
+
+    for tok in custom_token_bans.split(','):
+        if tok.isdigit():
+            logit_biases[tok] = -999
 
     inputs = generation_inputs()
     inputs.prompt = prompt.encode("UTF-8")


### PR DESCRIPTION
What's changed:

- Increased max logit_bias and banned_tokens size, because I've found out that 24 is not enough for some very sloppy models
- Added a parameter `banned_token_ids` to genparams to be able to ban tokens by id
- Adapted some names to work with SillyTavern (checked on 1.12.6)

Unfortunately, it seems that banned_phrases is broken now, it causes an access violaton (model Rocinante-12B-v1.Q8_0), so I couldn't check if that work.

> (Banned Phrase Detected:  shivers down her spine - Add ID 2641 to banlist at index 57, and rewinding 5 tokens)
['ivers (2641)', ]
exception: access violation reading 0x000001AAB2ACA000