### PR TITLE
Fix gpulayers autodetection for cublas & clblast backends - (Pull request koboldcpp-rocm#69 from matoro/main)

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4088,7 +4088,7 @@ def main(launch_args,start_server=True):
                 fetch_gpu_properties(False,True,True)
                 pass
             if args.gpulayers==-1:
-                if MaxMemory[0] > 0 and (not args.usecpu) and (args.usecublas or (args.usevulkan is not None) or args.useclblast or sys.platform=="darwin"):
+                if MaxMemory[0] > 0 and (not args.usecpu) and ((args.usecublas is not None) or (args.usevulkan is not None) or (args.useclblast is not None) or sys.platform=="darwin"):
                     extract_modelfile_params(args.model_param,args.sdmodel,args.whispermodel,args.mmproj)
                     layeramt = autoset_gpu_layers(args.contextsize,args.sdquant,args.blasbatchsize)
                     print(f"Auto Recommended GPU Layers: {layeramt}")


### PR DESCRIPTION
> This fixes `--gpulayers -1` paired with either `--usecublas` or `--useclblast` with no additional arguments.

> If you use e.g. `--usecublas --gpulayers -1`, then `args.usecublas = []`, not `None`, so it errors with `No GPU backend found, or could not automatically determine GPU layers. Please set it manually.`, even though a GPU is present.  Same for `useclblast`.  It works only if you pass an argument, e.g. `--usecublas lowvram --gpulayers -1`.

On the GUI, when selecting CuBLAS, it passes "normal" to the arguments list, but with the CLI it makes the list empty, and because:
``[]`` (empty list): returns Falsy
``["normal"]``: returns Truthy,

The GPU layer code would work in GUI but not via CLI; checking if it's ``not None`` rather than truthiness of the argument would make it work in both situations.

https://github.com/YellowRoseCx/koboldcpp-rocm/pull/69