### PR TITLE
Adding header X-Accel-Buffering set to no for SSE stream requests

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1482,6 +1482,7 @@ class ServerRequestHandler(http.server.SimpleHTTPRequestHandler):
     async def handle_sse_stream(self, genparams, api_format):
         global friendlymodelname, currfinishreason
         self.send_response(200)
+        self.send_header("X-Accel-Buffering", "no")
         self.send_header("cache-control", "no-cache")
         self.send_header("connection", "keep-alive")
         self.end_headers(content_type='text/event-stream')


### PR DESCRIPTION
Hello,

I have an nginx reverse proxy serving a kobold remote API. When using SSE during my session, the response was displayed only when all tokens were generated. I figured that nginx needed the "X-Accel-Buffering" from the API server in order to disable any buffering. 

I've built and tested the commit provided and can confirm it solved my problem.