### PR TITLE
Tweak mssing headcount in GGUF file for GPU autolayers

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -692,6 +692,8 @@ def autoset_gpu_layers(ctxsize,sdquanted,bbs): #shitty algo to determine how man
             else:
                 layers = ggufmeta[0]
                 headcount = ggufmeta[1]
+                if headcount == 0:
+                    headcount = layers
                 headkvlen = (ggufmeta[2] if ggufmeta[2] > 0 else 128)
                 ratio = (mem-usedmem)/(fsize*csmul*1.55)
                 computemem = layers*(4 if bbs <= 512 else (bbs/128))*headkvlen*cs*4*1.5 # apply blasbatchsize calculations if over 512


### PR DESCRIPTION
If the headcount is not registered in the GGUF metadata, due to an incomplete config.json during the initial conversion in GGUF, or due to a conversion of a GGML model into a GGUF model, then let's assume that headcount = layers, as it was the case during the pre-GQA era.

I just encountered the case today by downloading this model :
https://huggingface.co/mradermacher/airoboros-65b-gpt4-1.4.1-PI-8192-fp16-i1-GGUF

And I imagine there's several, if not many similar cases.