### PR TITLE
/props endpoint: provide context size through default_generation_settings

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2013,7 +2013,13 @@ Enter Prompt:<br>
         elif self.path=="/props":
             ctbytes = handle.get_chat_template()
             chat_template = ctypes.string_at(ctbytes).decode("UTF-8","ignore")
-            response_body = (json.dumps({"chat_template":chat_template,"total_slots":1}).encode())
+            response_body = (json.dumps({
+                "chat_template": chat_template,
+                "total_slots": 1,
+                "default_generation_settings": {
+                    "n_ctx": maxctx,
+                },
+            }).encode())
 
         elif self.path=="/api" or self.path=="/docs" or self.path.startswith(('/api/?json=','/api?json=','/docs/?json=','/docs?json=')):
             content_type = 'text/html'


### PR DESCRIPTION
It seems like a good idea to be able to directly pull and use the context size from the backend, rather than relying on users to manually getting both synced up all the time.

This adds the `default_generation_settings` dictionary with a single (for now) `n_ctx` entry to the `/props` endpoint response, which allows clients to update their context size to match the max context size used in koboldcpp.

It may be useful to include other default generation settings as well, but I am keeping it minimal for now.