### PR TITLE
use last path component for unnamed ggufs

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4496,6 +4496,14 @@ def main(launch_args,start_server=True):
     # sanitize and replace the default vanity name. remember me....
     if args.model_param and args.model_param!="":
         newmdldisplayname = os.path.basename(args.model_param)
+        if (
+            len(newmdldisplayname) < 25
+            and args.model_param.count("/") > 1
+            and newmdldisplayname.startswith("ggml-model-")
+            and newmdldisplayname.endswith(".gguf")
+        ):
+            # use the last path as model name, and stack on the quant info
+            newmdldisplayname = args.model_param.rsplit("/", 2)[1] + newmdldisplayname[10:]
         newmdldisplayname = os.path.splitext(newmdldisplayname)[0]
         friendlymodelname = "koboldcpp/" + sanitize_string(newmdldisplayname)
 

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4502,8 +4502,11 @@ def main(launch_args,start_server=True):
             and newmdldisplayname.startswith("ggml-model-")
             and newmdldisplayname.endswith(".gguf")
         ):
-            # use the last path as model name, and stack on the quant info
-            newmdldisplayname = args.model_param.rsplit("/", 2)[1] + newmdldisplayname[10:]
+            # if there are .safetensors files in the same dir, we can safely assume this is a model dir
+            # and the last path component is the model name
+            if any(p.endswith(".safetensors") for p in os.listdir(os.path.dirname(args.model_param))):
+                # use the last path as model name, and stack on the quant info
+                newmdldisplayname = args.model_param.rsplit("/", 2)[1] + newmdldisplayname[10:]
         newmdldisplayname = os.path.splitext(newmdldisplayname)[0]
         friendlymodelname = "koboldcpp/" + sanitize_string(newmdldisplayname)
 


### PR DESCRIPTION
Usually, a ggml-model-XXX.gguf file will reside in the directory named after the model, e.g. if the user generated the quant themselves and didn't move it. Instead of displaying models as `koboldcpp/ggml-model-xxx`, this picks the last directory component and tacks the quant info on it, but only if there is at least one file with the `.safetensors` extension in the same directory.