### PR TITLE
PoC: add chat template heuristics

### DIFF
--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -1,0 +1,113 @@
+[
+{
+    "search": ["<|im_start|>assistant", "<|im_end|>", "<|im_sep|>"],
+    "name": "ChatML (Phi 4)",
+    "adapter": {
+        "system_start": "<|im_start|>system<|im_sep|>",
+        "system_end": "<|im_end|>",
+        "user_start": "<|im_start|>user<|im_sep|>",
+        "user_end": "<|im_end|>",
+        "assistant_start": "<|im_start|>assistant<|im_sep|>",
+        "assistant_end": "<|im_end|>"
+    }
+}, {
+    "search": ["<|im_start|>assistant", "<|im_end|>", "You are provided with function signatures within <tools>"],
+    "name": "ChatML (Qwen 2.5 based).",
+    "adapter": {
+        "system_start": "<|im_start|>system\n\n",
+        "system_end": "<|im_end|>\n\n",
+        "user_start": "<|im_start|>user\n\n",
+        "user_end": "<|im_end|>\n\n",
+        "assistant_start": "<|im_start|>assistant\n\n",
+        "assistant_end": "<|im_end|>\n\n",
+        "tools_start": "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n\n<tools>\n",
+        "tools_end": "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n"
+    }
+}, {
+    "search": ["<|im_start|>assistant", "<|im_end|>"],
+    "name": "ChatML (Generic).",
+    "adapter": {
+        "system_start": "<|im_start|>system\n\n",
+        "system_end": "<|im_end|>\n\n",
+        "user_start": "<|im_start|>user\n\n",
+        "user_end": "<|im_end|>\n\n",
+        "assistant_start": "<|im_start|>assistant\n\n",
+        "assistant_end": "<|im_end|>\n\n"
+    }
+}, {
+    "search": ["System role not supported", "<start_of_turn>"],
+    "name": "Google Gemma 2.",
+    "adapter": {
+        "user_start": "<start_of_turn>user\n",
+        "user_end": "<end_of_turn>\n",
+        "assistant_start": "<start_of_turn>model\n",
+        "assistant_end": "<end_of_turn>\n"
+    }
+}, {
+    "search": ["<|start_header_id|>system"],
+    "name": "Llama 3.x.",
+    "adapter": {
+        "system_start": "<|start_header_id|>system<|end_header_id|>\n\n",
+        "system_end": "<|eot_id|>\n\n",
+        "user_start": "<|start_header_id|>user<|end_header_id|>\n\n",
+        "user_end": "<|eot_id|>\n\n",
+        "assistant_start": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+        "assistant_end": "<|eot_id|>\n\n"
+    }
+}, {
+    "search": ["[/INST]", "[SYSTEM_PROMPT]"],
+    "name": "Mistral V7 (with system prompt)",
+    "adapter": {
+        "system_start": "[SYSTEM_PROMPT] ",
+        "system_end": "[/SYSTEM_PROMPT]",
+        "user_start": "[INST] ",
+        "user_end": "[/INST]",
+        "assistant_start": " ",
+        "assistant_end": "</s>"
+    }
+}, {
+    "search": ["[/INST]", "\"[INST] \" + system_message"],
+    "name": "Mistral V3",
+    "adapter": {
+        "system_start": "[INST] ",
+        "system_end": "[/INST] ",
+        "user_start": "[INST] ",
+        "user_end": "[/INST] ",
+        "assistant_start": "",
+        "assistant_end": "</s>"
+    }
+}, {
+    "search": ["[/INST]"],
+    "name": "Mistral (Generic)",
+    "adapter": {
+        "system_start": "[INST]",
+        "system_end": "[/INST]\n",
+        "user_start": "[INST]",
+        "user_end": "[/INST]\n",
+        "assistant_start": "",
+        "assistant_end": "</s>"
+    }
+}, {
+    "search": ["<|system|>", "<|user|>"],
+    "name": "Phi 3.5",
+    "adapter": {
+        "system_start": "<|system|>\n",
+        "system_end": "<|end|>\n",
+        "user_start": "<|user|>\n",
+        "user_end": "<|end|>\n",
+        "assistant_start": "<|assistant|>\n",
+        "assistant_end": "<|end|>\n"
+    }
+}, {
+    "search": ["<|START_OF_TURN_TOKEN|>"],
+    "name": "Cohere (Aya Expanse 32B based)",
+    "adapter": {
+        "system_start": "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
+        "system_end": "<|END_OF_TURN_TOKEN|>",
+        "user_start": "<|START_OF_TURN_TOKEN|><|USER_TOKEN|>",
+        "user_end": "<|END_OF_TURN_TOKEN|>",
+        "assistant_start": "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",
+        "assistant_end": "<|END_OF_TURN_TOKEN|>"
+    }
+}
+]

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4737,6 +4737,17 @@ def main(launch_args,start_server=True):
                     "assistant_start": "<|assistant|>\n",
                     "assistant_end": "<|end|>\n",
                 }
+            elif "<|START_OF_TURN_TOKEN|>" in chat_template:
+                print("Chat completion heuristic: Cohere (Aya Expanse 32B based)")
+                chatcompl_adapter = {
+                    "system_start": "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
+                    "system_end": "<|END_OF_TURN_TOKEN|>",
+                    "user_start": "<|START_OF_TURN_TOKEN|><|USER_TOKEN|>",
+                    "user_end": "<|END_OF_TURN_TOKEN|>",
+                    "assistant_start": "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",
+                    "assistant_end": "<|END_OF_TURN_TOKEN|>",
+                }
+
 
 
     #handle loading image model

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4657,7 +4657,6 @@ def main(launch_args,start_server=True):
             if "<|im_start|>assistant" in chat_template and "<|im_end|>" in chat_template:
                 if "<|im_sep|>" in chat_template:
                     print("Chat completion heuristic: ChatML (Phi 4)")
-                    # Phi 4 ChatML
                     chatcompl_adapter = {
                         "system_start": "<|im_start|>system<|im_sep|>",
                         "system_end": "<|im_end|>",
@@ -4668,7 +4667,6 @@ def main(launch_args,start_server=True):
                     }
                 elif "You are provided with function signatures within <tools>" in chat_template:
                     print("Chat completion heuristic: ChatML (Qwen 2.5 based).")
-                    # Qwen 2.5 ChatML
                     chatcompl_adapter = {
                         "system_start": "<|im_start|>system\n\n",
                         "system_end": "<|im_end|>\n\n",
@@ -4692,7 +4690,6 @@ def main(launch_args,start_server=True):
 
             elif "System role not supported" in chat_template and "<start_of_turn>" in chat_template:
                 print("Chat completion heuristic: Google Gemma 2.")
-                # Google Gemma 2
                 chatcompl_adapter = {
                     "user_start": "<start_of_turn>user\n",
                     "user_end": "<end_of_turn>\n",
@@ -4700,7 +4697,6 @@ def main(launch_args,start_server=True):
                     "assistant_end": "<end_of_turn>\n",
                 }
             elif "<|start_header_id|>system" in chat_template:
-                # Llama 3.x
                 print("Chat completion heuristic: Llama 3.x.")
                 chatcompl_adapter = {
                     "system_start": "<|start_header_id|>system<|end_header_id|>\n\n",

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4751,7 +4751,11 @@ def main(launch_args,start_server=True):
                     "assistant_start": "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",
                     "assistant_end": "<|END_OF_TURN_TOKEN|>",
                 }
+        if chatcompl_adapter is None:
+            print("Chat template heuristics failed to identify chat completions format. Alpaca will be used.")
 
+    if chatcompl_adapter is None and not args.chatcompletionsadapter:
+        print("Note: Alpaca format will be used for OpenAI Compatible API chat completions. Use --chatcompletionsadapter=AutoGuess to use chat template heuristics.")
 
 
     #handle loading image model

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4716,6 +4716,16 @@ def main(launch_args,start_server=True):
                     "assistant_start": "",
                     "assistant_end": "</s>",
                 }
+            elif "<|system|>" in chat_template and "<|user|>" in chat_template:
+                print("Chat completion heuristic: Phi 3.5")
+                chatcompl_adapter = {
+                    "system_start": "<|system|>\n",
+                    "system_end": "<|end|>\n",
+                    "user_start": "<|user|>\n",
+                    "user_end": "<|end|>\n",
+                    "assistant_start": "<|assistant|>\n",
+                    "assistant_end": "<|end|>\n",
+                }
 
 
     #handle loading image model

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4711,7 +4711,17 @@ def main(launch_args,start_server=True):
                     "assistant_end": "<|eot_id|>\n\n",
                 }
             elif "[/INST]" in chat_template:
-                if "\"[INST] \" + system_message" in chat_template:
+                if "[SYSTEM_PROMPT]" in chat_template:
+                    print("Chat completion heuristic: Mistral V7 (with system prompt)")
+                    chatcompl_adapter = {
+                        "system_start": "[SYSTEM_PROMPT] ",
+                        "system_end": "[/SYSTEM_PROMPT]",
+                        "user_start": "[INST] ",
+                        "user_end": "[/INST]",
+                        "assistant_start": " ",
+                        "assistant_end": "</s>",
+                    }
+                elif "\"[INST] \" + system_message" in chat_template:
                     print("Chat completion heuristic: Mistral V3")
                     chatcompl_adapter = {
                         "system_start": "[INST] ",

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4709,6 +4709,8 @@ def main(launch_args,start_server=True):
             elif "[/INST]" in chat_template:
                 print("Chat completion heuristic: Mistral (Generic)")
                 chatcompl_adapter = {
+                    "system_start": "[INST]",
+                    "system_end": "[/INST]\n",
                     "user_start": "[INST]",
                     "user_end": "[/INST]\n",
                     "assistant_start": "",

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4706,7 +4706,14 @@ def main(launch_args,start_server=True):
                     "assistant_start": "<|start_header_id|>assistant<|end_header_id|>\n\n",
                     "assistant_end": "<|eot_id|>\n\n",
                 }
-
+            elif "[/INST]" in chat_template:
+                print("Chat completion heuristic: Mistral (Generic)")
+                chatcompl_adapter = {
+                    "user_start": "[INST]",
+                    "user_end": "[/INST]\n",
+                    "assistant_start": "",
+                    "assistant_end": "</s>",
+                }
 
 
     #handle loading image model

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4413,7 +4413,7 @@ def main(launch_args,start_server=True):
             print("Warning: Saved story file invalid or not found. No story will be preloaded into server.")
 
     # try to read chat completions adapter
-    if args.chatcompletionsadapter:
+    if args.chatcompletionsadapter and "autoguess" not in args.chatcompletionsadapter.lower():
         global chatcompl_adapter
         ccadapter_path = None
         canload = False
@@ -4648,7 +4648,11 @@ def main(launch_args,start_server=True):
             exitcounter = 999
             exit_with_error(3,"Could not load text model: " + modelname)
 
-    if chatcompl_adapter is None:
+    if (
+        chatcompl_adapter is None
+        and args.chatcompletionsadapter
+        and "autoguess" in args.chatcompletionsadapter.lower()
+    ):
         # Try to derive chat completions adapter from chat template, now that we have the model loaded
         ctbytes = handle.get_chat_template()
         chat_template = ctypes.string_at(ctbytes).decode("UTF-8","ignore")

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4667,6 +4667,16 @@ def main(launch_args,start_server=True):
                     "tools_start": "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n\n<tools>\n", # Qwen 2.5 -- if ambiguous & worth it, use this string to ID/split out
                     "tools_end": "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n",
                 }
+            elif "System role not supported" in chat_template and "<start_of_turn>" in chat_template:
+                print("Chat completion heuristic: Google Gemma 2.")
+                # Google Gemma 2
+                chatcompl_adapter = {
+                    "user_start": "<start_of_turn>user\n",
+                    "user_end": "<end_of_turn>\n",
+                    "assistant_start": "<start_of_turn>model\n",
+                    "assistant_end": "<end_of_turn>\n",
+                }
+
 
     #handle loading image model
     if args.sdmodel and args.sdmodel!="":

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4707,15 +4707,26 @@ def main(launch_args,start_server=True):
                     "assistant_end": "<|eot_id|>\n\n",
                 }
             elif "[/INST]" in chat_template:
-                print("Chat completion heuristic: Mistral (Generic)")
-                chatcompl_adapter = {
-                    "system_start": "[INST]",
-                    "system_end": "[/INST]\n",
-                    "user_start": "[INST]",
-                    "user_end": "[/INST]\n",
-                    "assistant_start": "",
-                    "assistant_end": "</s>",
-                }
+                if "\"[INST] \" + system_message" in chat_template:
+                    print("Chat completion heuristic: Mistral V3")
+                    chatcompl_adapter = {
+                        "system_start": "[INST] ",
+                        "system_end": "[/INST] ",
+                        "user_start": "[INST] ",
+                        "user_end": "[/INST] ",
+                        "assistant_start": "",
+                        "assistant_end": "</s>",
+                    }
+                else:
+                    print("Chat completion heuristic: Mistral (Generic)")
+                    chatcompl_adapter = {
+                        "system_start": "[INST]",
+                        "system_end": "[/INST]\n",
+                        "user_start": "[INST]",
+                        "user_end": "[/INST]\n",
+                        "assistant_start": "",
+                        "assistant_end": "</s>",
+                    }
             elif "<|system|>" in chat_template and "<|user|>" in chat_template:
                 print("Chat completion heuristic: Phi 3.5")
                 chatcompl_adapter = {

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4656,7 +4656,7 @@ def main(launch_args,start_server=True):
             # "Better than nothing" simple heuristics
             if "<|im_start|>assistant" in chat_template and "<|im_end|>" in chat_template:
                 if "<|im_sep|>" in chat_template:
-                    print("Chat completion heuristic: Phi 4")
+                    print("Chat completion heuristic: ChatML (Phi 4)")
                     # Phi 4 ChatML
                     chatcompl_adapter = {
                         "system_start": "<|im_start|>system<|im_sep|>",
@@ -4666,7 +4666,7 @@ def main(launch_args,start_server=True):
                         "assistant_start": "<|im_start|>assistant<|im_sep|>",
                         "assistant_end": "<|im_end|>",
                     }
-                else:
+                elif "You are provided with function signatures within <tools>" in chat_template:
                     print("Chat completion heuristic: ChatML (Qwen 2.5 based).")
                     # Qwen 2.5 ChatML
                     chatcompl_adapter = {
@@ -4679,6 +4679,17 @@ def main(launch_args,start_server=True):
                         "tools_start": "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n\n<tools>\n", # Qwen 2.5 -- if ambiguous & worth it, use this string to ID/split out
                         "tools_end": "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n",
                     }
+                else:
+                    print("Chat completion heuristic: ChatML (Generic).")
+                    chatcompl_adapter = {
+                        "system_start": "<|im_start|>system\n\n",
+                        "system_end": "<|im_end|>\n\n",
+                        "user_start": "<|im_start|>user\n\n",
+                        "user_end": "<|im_end|>\n\n",
+                        "assistant_start": "<|im_start|>assistant\n\n",
+                        "assistant_end": "<|im_end|>\n\n",
+                    }
+
             elif "System role not supported" in chat_template and "<start_of_turn>" in chat_template:
                 print("Chat completion heuristic: Google Gemma 2.")
                 # Google Gemma 2

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4655,18 +4655,30 @@ def main(launch_args,start_server=True):
         if chat_template != "":
             # "Better than nothing" simple heuristics
             if "<|im_start|>assistant" in chat_template and "<|im_end|>" in chat_template:
-                print("Chat completion heuristic: ChatML (Qwen 2.5 based).")
-                # ChatML
-                chatcompl_adapter = {
-                    "system_start": "<|im_start|>system\n\n",
-                    "system_end": "<|im_end|>\n\n",
-                    "user_start": "<|im_start|>user\n\n",
-                    "user_end": "<|im_end|>\n\n",
-                    "assistant_start": "<|im_start|>assistant\n\n",
-                    "assistant_end": "<|im_end|>\n\n",
-                    "tools_start": "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n\n<tools>\n", # Qwen 2.5 -- if ambiguous & worth it, use this string to ID/split out
-                    "tools_end": "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n",
-                }
+                if "<|im_sep|>" in chat_template:
+                    print("Chat completion heuristic: Phi 4")
+                    # Phi 4 ChatML
+                    chatcompl_adapter = {
+                        "system_start": "<|im_start|>system<|im_sep|>",
+                        "system_end": "<|im_end|>",
+                        "user_start": "<|im_start|>user<|im_sep|>",
+                        "user_end": "<|im_end|>",
+                        "assistant_start": "<|im_start|>assistant<|im_sep|>",
+                        "assistant_end": "<|im_end|>",
+                    }
+                else:
+                    print("Chat completion heuristic: ChatML (Qwen 2.5 based).")
+                    # Qwen 2.5 ChatML
+                    chatcompl_adapter = {
+                        "system_start": "<|im_start|>system\n\n",
+                        "system_end": "<|im_end|>\n\n",
+                        "user_start": "<|im_start|>user\n\n",
+                        "user_end": "<|im_end|>\n\n",
+                        "assistant_start": "<|im_start|>assistant\n\n",
+                        "assistant_end": "<|im_end|>\n\n",
+                        "tools_start": "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n\n<tools>\n", # Qwen 2.5 -- if ambiguous & worth it, use this string to ID/split out
+                        "tools_end": "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n",
+                    }
             elif "System role not supported" in chat_template and "<start_of_turn>" in chat_template:
                 print("Chat completion heuristic: Google Gemma 2.")
                 # Google Gemma 2
@@ -4676,6 +4688,18 @@ def main(launch_args,start_server=True):
                     "assistant_start": "<start_of_turn>model\n",
                     "assistant_end": "<end_of_turn>\n",
                 }
+            elif "<|start_header_id|>system" in chat_template:
+                # Llama 3.x
+                print("Chat completion heuristic: Llama 3.x.")
+                chatcompl_adapter = {
+                    "system_start": "<|start_header_id|>system<|end_header_id|>\n\n",
+                    "system_end": "<|eot_id|>\n\n",
+                    "user_start": "<|start_header_id|>user<|end_header_id|>\n\n",
+                    "user_end": "<|eot_id|>\n\n",
+                    "assistant_start": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+                    "assistant_end": "<|eot_id|>\n\n",
+                }
+
 
 
     #handle loading image model


### PR DESCRIPTION
The fallback chat template adapter of Vicuna is not ideal in some cases (e.g. a test against a sub-portion of the BBC news classification task on Kaggle gave an 82% accuracy with Vicuna and 88% with the official ChatML format for a q4_k_m Qwen 2.5 3B-Instruct gguf).

This PR adds a proof of concept simple heuristic which looks at the chat template and upgrades the adapter when it is able to.

- [ ] Determine where this should go. koboldcpp.py seems big enough as it is, but the project does not seem to split into .py files often/at all.
- [ ] Extend the cases to cover more chat templates, e.g. Llama 3.1, Mistral versions, etc.

Alternative approach: expose the llama chat template mechanism and use that.