### PR TITLE
Remote Tunnel for ARM64 Linux

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4631,6 +4631,9 @@ def setuptunnel(has_sd):
             elif sys.platform=="darwin":
                 print("Starting Cloudflare Tunnel for MacOS, please wait...", flush=True)
                 tunnelproc = subprocess.Popen(f"./cloudflared tunnel --url {httpsaffix}://localhost:{args.port}", text=True, encoding='utf-8', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+            elif sys.platform == "linux" and platform.uname()[4] == 'aarch64':
+                print("Starting Cloudflare Tunnel for ARM64 Linux, please wait...", flush=True)
+                tunnelproc = subprocess.Popen(f"./cloudflared-linux-arm64 tunnel --url {httpsaffix}://localhost:{args.port}", text=True, encoding='utf-8', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
             else:
                 print("Starting Cloudflare Tunnel for Linux, please wait...", flush=True)
                 tunnelproc = subprocess.Popen(f"./cloudflared-linux-amd64 tunnel --url {httpsaffix}://localhost:{args.port}", text=True, encoding='utf-8', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
@@ -4676,6 +4679,13 @@ def setuptunnel(has_sd):
                 subprocess.run("curl -fL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz -o cloudflared-darwin-amd64.tgz", shell=True, capture_output=True, text=True, check=True, encoding='utf-8')
                 subprocess.run("tar -xzf cloudflared-darwin-amd64.tgz", shell=True)
                 subprocess.run("chmod +x 'cloudflared'", shell=True)
+        elif sys.platform == "linux" and platform.uname()[4] == 'aarch64':
+            if os.path.exists("cloudflared-linux-arm64") and os.path.getsize("cloudflared-linux-arm64") > 1000000:
+                print("Cloudflared file exists, reusing it...")
+            else:
+                print("Downloading Cloudflare Tunnel for ARM64 Linux...")
+                subprocess.run("curl -fL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64 -o cloudflared-linux-arm64", shell=True, capture_output=True, text=True, check=True, encoding='utf-8')
+                subprocess.run("chmod +x 'cloudflared-linux-arm64'", shell=True)
         else:
             if os.path.exists("cloudflared-linux-amd64") and os.path.getsize("cloudflared-linux-amd64") > 1000000:
                 print("Cloudflared file exists, reusing it...")

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4631,7 +4631,7 @@ def setuptunnel(has_sd):
             elif sys.platform=="darwin":
                 print("Starting Cloudflare Tunnel for MacOS, please wait...", flush=True)
                 tunnelproc = subprocess.Popen(f"./cloudflared tunnel --url {httpsaffix}://localhost:{args.port}", text=True, encoding='utf-8', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-            elif sys.platform == "linux" and platform.uname()[4] == 'aarch64':
+            elif sys.platform == "linux" and platform.uname()[4] == "aarch64":
                 print("Starting Cloudflare Tunnel for ARM64 Linux, please wait...", flush=True)
                 tunnelproc = subprocess.Popen(f"./cloudflared-linux-arm64 tunnel --url {httpsaffix}://localhost:{args.port}", text=True, encoding='utf-8', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
             else:
@@ -4679,7 +4679,7 @@ def setuptunnel(has_sd):
                 subprocess.run("curl -fL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz -o cloudflared-darwin-amd64.tgz", shell=True, capture_output=True, text=True, check=True, encoding='utf-8')
                 subprocess.run("tar -xzf cloudflared-darwin-amd64.tgz", shell=True)
                 subprocess.run("chmod +x 'cloudflared'", shell=True)
-        elif sys.platform == "linux" and platform.uname()[4] == 'aarch64':
+        elif sys.platform == "linux" and platform.uname()[4] == "aarch64":
             if os.path.exists("cloudflared-linux-arm64") and os.path.getsize("cloudflared-linux-arm64") > 1000000:
                 print("Cloudflared file exists, reusing it...")
             else:


### PR DESCRIPTION
## What has been done:
If running on ARM64 Linux, download and run the correct Cloudflare binary for ARM64 Linux.

## Before
```
python3 koboldcpp.py --nomodel --usecpu --threads 4 --remotetunnel
...
Downloading Cloudflare Tunnel for Linux...
Attempting to start tunnel thread...
Starting Cloudflare Tunnel for Linux, please wait...
Error: Could not create cloudflare tunnel!
More Info:
/bin/sh: 1: ./cloudflared-linux-amd64: Exec format error
```

## After
```
python3 koboldcpp.py --nomodel --usecpu --threads 4 --remotetunnel
...
Downloading Cloudflare Tunnel for ARM64 Linux...
Attempting to start tunnel thread...
Starting Cloudflare Tunnel for ARM64 Linux, please wait...
Your remote Kobold API can be found at https://XXX.trycloudflare.com/api
Your remote OpenAI Compatible API can be found at https://XXX.trycloudflare.com/v1
======

Your remote tunnel is ready, please connect to https://XXX.trycloudflare.com
```
