### PR TITLE
Sort models configs in admin menu

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2408,7 +2408,7 @@ Enter Prompt:<br>
             opts = []
             if args.admin and args.admindir and os.path.exists(args.admindir) and self.check_header_password(args.adminpassword):
                 dirpath = os.path.abspath(args.admindir)
-                opts = [f for f in os.listdir(dirpath) if f.endswith(".kcpps") and os.path.isfile(os.path.join(dirpath, f))]
+                opts = [f for f in sorted(os.listdir(dirpath)) if f.endswith(".kcpps") and os.path.isfile(os.path.join(dirpath, f))]
             response_body = (json.dumps(opts).encode())
 
         elif self.path.endswith(('/api/extra/perf')):


### PR DESCRIPTION
`os.listdir` order is relying on filesystem details, and it's neither date created/modified, nor alphanumeric. 
Explicitly `sorted` output is generally more readable.
Alternatively, we could sort it in UI, leaving API response as is; not sure what would be better approach.