### PR TITLE
Make token validation constant-time

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -10,6 +10,7 @@
 
 import copy
 import ctypes
+import hmac
 import multiprocessing
 import os
 import math
@@ -2259,7 +2260,7 @@ class KcppServerRequestHandler(http.server.SimpleHTTPRequestHandler):
                 auth_header = self.headers['authorization']
             if auth_header is not None and auth_header.startswith('Bearer '):
                 token = auth_header[len('Bearer '):].strip()
-                if token==target_password:
+                if hmac.compare_digest(token.encode(), target_password.encode()):
                     auth_ok = True
         return auth_ok
 


### PR DESCRIPTION
the `check_header_password()` function is doing byte-at-a-time equality checking to check if the token is valid(i.e. submitted_token == valid_token).  This method leaks timing information over the network, and can be used by an attacker to mount a timing attack against the token.

Recommend the use of `hmac.compare_digest` to mitigate against the possibility of timing attacks against the token.