### PR TITLE
Allow Inverse DynaTemp

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -1628,7 +1628,7 @@ const std::vector<samplers> & sampler_order, llama_grammar * grammar, float dyna
                     sampler_typical(&candidates_p, typical_p, 1);
                     break;
                 case KCPP_SAMPLER_TEMP:
-                    if (dynatemp_range>0)
+                    if (dynatemp_range!=0)
                     {
                         float dynatemp_min = temp - dynatemp_range;
                         float dynatemp_max = temp + dynatemp_range;


### PR DESCRIPTION
Use DynaTemp Range != 0 instead of >0

This allows setting DynaTemp Range inverse (Min > Max) which supports some interesting output results akin to XTC.