### PR TITLE
Add Rep Pen to Top N Sigma sampler chain

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -1631,6 +1631,7 @@ const std::vector<samplers> & sampler_order, llama_grammar * grammar, float dyna
             sample_temperature(&candidates_p, temp, smoothing_factor);
         }
         sample_top_n_sigma(&candidates_p, nsigma);
+        sample_rep_pen(n_ctx, rep_pen_range, rep_pen, rep_pen_slope, presence_penalty, &candidates_p);
         sample_xtc(&candidates_p, xtc_threshold, xtc_probability, rng);
         id = sample_token(&candidates_p, rng);
     }


### PR DESCRIPTION
In all the tests when placed after nsigma, it was consistent with formatting and outputs were normal or good quality. When placed somewhere before, it couldn't even pass the first five seeds without breaking format or giving poor quality outputs.

STscript used for testing:
```
/let seed [199803,1337,42,420,69420] |
/let rep_pen [1.15,1.3,1.5] |
/let nsigma [0.75,1.25] |

/foreach {{var::nsigma}} {: it= i=
	/foreach {{var::rep_pen}} {: jt= j=
		/foreach {{var::seed}} {: kt= k=
			/tc-ephemeral dict={"nsigma":{{var::it}},"rep_pen":{{var::jt}},"seed":{{var::kt}}} |
			
			/swipes-swipe |
		:}|
	:}|
:}|
```