### PR TITLE
AutoGuess: GLM-4

### DIFF
--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -170,7 +170,8 @@
     "search": ["[gMASK]<sop>"],
     "name": "GLM-4",
     "adapter": {
-        "system_start": "[gMASK]<sop><|system|>\n",
+        "chat_start": "[gMASK]<sop>",
+        "system_start": "<|system|>\n",
         "system_end": "",
         "user_start": "<|user|>\n",
         "user_end": "",

--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -166,5 +166,16 @@
         "assistant_start": "<｜Assistant｜>",
         "assistant_end": "<｜end▁of▁sentence｜>"
     }
+}, {
+    "search": ["[gMASK]<sop>"],
+    "name": "GLM-4",
+    "adapter": {
+        "system_start": "[gMASK]<sop><|system|>\n",
+        "system_end": "",
+        "user_start": "<|user|>\n",
+        "user_end": "",
+        "assistant_start": "<|assistant|>\n",
+        "assistant_end": ""
+    }
 }
 ]

--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -112,10 +112,11 @@
         "assistant_end": "</s>"
     }
 }, {
-    "search": ["<|system|>", "<|user|>","[gMASK]"],
+    "search": ["[gMASK]<sop>"],
     "name": "GLM-4",
     "adapter": {
-        "system_start": "[gMASK]<sop><|system|>\n",
+        "chat_start": "[gMASK]<sop>",
+        "system_start": "<|system|>\n",
         "system_end": "",
         "user_start": "<|user|>\n",
         "user_end": "",
@@ -165,18 +166,6 @@
         "user_end": "",
         "assistant_start": "<｜Assistant｜>",
         "assistant_end": "<｜end▁of▁sentence｜>"
-    }
-}, {
-    "search": ["[gMASK]<sop>"],
-    "name": "GLM-4",
-    "adapter": {
-        "chat_start": "[gMASK]<sop>",
-        "system_start": "<|system|>\n",
-        "system_end": "",
-        "user_start": "<|user|>\n",
-        "user_end": "",
-        "assistant_start": "<|assistant|>\n",
-        "assistant_end": ""
     }
 }
 ]

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2049,7 +2049,7 @@ def transform_genparams(genparams, api_format):
         if api_format==4 or api_format==7: #handle ollama chat here too
             # translate openai chat completion messages format into one big string.
             messages_array = genparams.get('messages', [])
-            messages_string = ""
+            messages_string = adapter_obj.get("chat_start", "")
             system_message_start = adapter_obj.get("system_start", "\n### Instruction:\n")
             system_message_end = adapter_obj.get("system_end", "")
             user_message_start = adapter_obj.get("user_start", "\n### Instruction:\n")


### PR DESCRIPTION
~I'm not sure how to handle the unconditional prefix `[gMASK]<sop>`. This is currently inserted as the system message prefix along with `<|system|>\n`, but even without a system message, these two tokens should be present. There is no entry in the adapter for "start with this sequence" AFAICT.~

Update: I added a `chat_start` entry to the adapters. This is used as the start sequence when present. This should make the GLM-4 output work for cases with and without a system mesage, I believe.