### PR TITLE
fix mistral v7 automatic template

### DIFF
--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -85,8 +85,8 @@
         "system_start": "[SYSTEM_PROMPT] ",
         "system_end": "[/SYSTEM_PROMPT]",
         "user_start": "[INST] ",
-        "user_end": "[/INST]",
-        "assistant_start": " ",
+        "user_end": "[/INST] ",
+        "assistant_start": "",
         "assistant_end": "</s>"
     }
 }, {


### PR DESCRIPTION
The current Mistral v7 template sets a space for `assistant_start`, which automatically gets turned into a stop sequence. As a result inference immediately stops when the model generates a space :rofl:.