### PR TITLE
fix: workaround for default clip_skip issues

### DIFF
--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -368,6 +368,17 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
     bool dotile = (sd_params->width>768 || sd_params->height>768) && !notiling;
     set_sd_vae_tiling(sd_ctx,dotile); //changes vae tiling, prevents memory related crash/oom
 
+    if (sd_params->clip_skip <= 0) {
+        // workaround for clip_skip being "stuck" at the previous requested value
+        // 2 is the default for all recent base models (SD2, SDXL, Flux, SD3)
+        if (sd_version_is_sd1((SDVersion)loadedsdver)) {
+            sd_params->clip_skip = 1;
+        }
+        else {
+            sd_params->clip_skip = 2;
+        }
+    }
+
     //for img2img
     sd_image_t input_image = {0,0,0,nullptr};
     std::vector<uint8_t> image_buffer;


### PR DESCRIPTION
Sets the clip_skip value explicitly to 1 or 2 for all generation requests, aligning with the tests in the Conditioner objects in conditioner.hpp.

This should fix #1546 regardless of future changes to the default behavior of sdcpp. This workaround can be removed once a proper fix is implemented in sdcpp.