### PR TITLE
Add memoized cache to `llama_grammar_reject_candidates_for_stack`

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -1773,6 +1773,7 @@ static void load_grammar(const std::string & gammarstr)
 {
     if(grammar!=nullptr) //on demand free when next grammar is loaded
     {
+        llama_grammar_reset_memos();
         llama_grammar_free_impl(grammar);
         grammar = nullptr;
     }

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -890,30 +890,31 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
     auto stack_hash_size  = sizeof(stack[0]) * stack.size();
     auto stack_hash       = std::hash<bytes>{}({ stack_hash_start, stack_hash_size });
 
-    llama_grammar_candidates* cache_target = nullptr;
-    
-    // Only check stash hash first - these are usually ~24b, and almost always under 64b
-    if (auto& cache_hit = memo_cache.find(stack_hash); cache_hit != memo_cache.end()) {
-        // Only attempt to memoize candidate lists under 1280
-        // >75% of candidate lists are under 1280 and 50% are under 640b. Most 'problem' loops are under 24b
-        // However, candidate lists can be over 72k, so we need to limit our checks
-        auto candidates_hash_size  = sizeof(candidates[0]) * candidates.size();
-        if (candidates_hash_size < 1280) {
-            auto& candidates_memos = cache_hit->second;
-            auto candidates_hash_start = reinterpret_cast<const char *>(candidates.data());
-            auto candidates_hash       = std::hash<bytes>{}({ candidates_hash_start, candidates_hash_size });
-            if (auto& cache_hit2 = candidates_memos.find(candidates_hash); cache_hit2 != candidates_memos.end()) {
+    llama_grammar_candidates * cache_target = nullptr;
+
+    // Only attempt to memoize candidate lists under 1280
+    // >75% of candidate lists are under 1280 and 50% are under 640b. Most 'problem' loops are under 24b
+    // However, candidate lists can be over 72k, so we need to limit our checks
+    // Doing an over-aggressive size cutoff first befor any other processing 'saves' easy cases
+    // extra processing but still rescues 'hard' cases from slow down or hangs.
+    // This leads to a speed up of both easy and hard cases.
+    const size_t hash_cutoff          = 80;
+    auto         candidates_hash_size = sizeof(candidates[0]) * candidates.size();
+    if (candidates_hash_size < hash_cutoff) {
+        // Only check stash hash first - these are usually ~24b, and almost always under 64b
+        if (auto & cache_hit = memo_cache.find(stack_hash); cache_hit != memo_cache.end()) {
+            auto & candidates_memos      = cache_hit->second;
+            auto   candidates_hash_start = reinterpret_cast<const char *>(candidates.data());
+            auto   candidates_hash       = std::hash<bytes>{}({ candidates_hash_start, candidates_hash_size });
+            if (auto & cache_hit2 = candidates_memos.find(candidates_hash); cache_hit2 != candidates_memos.end()) {
                 return cache_hit2->second;
-            }
-            else {
+            } else {
                 cache_target = &(candidates_memos[candidates_hash]);
             }
+        } else {
+            memo_cache[stack_hash];
         }
     }
-    else {
-        memo_cache[stack_hash];
-    }
-
 
     const llama_grammar_element * stack_pos = stack.back();
 

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -892,9 +892,12 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
 
     llama_grammar_candidates * cache_target = nullptr;
 
-    // Only attempt to memoize candidate lists under 1280
-    // >75% of candidate lists are under 1280 and 50% are under 640b. Most 'problem' loops are under 24b
-    // However, candidate lists can be over 72k, so we need to limit our checks
+    // Tests show that >75% of candidate lists are under 1280 and 50% are under 640b.
+    // Most 'problem' loops are under 24b. However, candidate lists can be over 72k,
+    // so we need to limit our checks.
+
+
+    // We'll only attempt to memoize candidate lists under 80b
     // Doing an over-aggressive size cutoff first befor any other processing 'saves' easy cases
     // extra processing but still rescues 'hard' cases from slow down or hangs.
     // This leads to a speed up of both easy and hard cases.

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -899,7 +899,6 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
     // Most 'problem' loops are under 24b. However, candidate lists can be over 72k,
     // so we need to limit our checks.
 
-
     // We'll only attempt to memoize candidate lists under 80b
     // Doing an over-aggressive size cutoff first befor any other processing 'saves' easy cases
     // extra processing but still rescues 'hard' cases from slow down or hangs.
@@ -908,11 +907,11 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
     auto         candidates_hash_size = sizeof(candidates[0]) * candidates.size();
     if (candidates_hash_size < hash_cutoff) {
         // Only check stash hash first - these are usually ~24b, and almost always under 64b
-        if (auto & cache_hit = memo_cache.find(stack_hash); cache_hit != memo_cache.end()) {
+        if (auto cache_hit = memo_cache.find(stack_hash); cache_hit != memo_cache.end()) {
             auto & candidates_memos      = cache_hit->second;
             auto   candidates_hash_start = reinterpret_cast<const char *>(candidates.data());
             auto   candidates_hash       = std::hash<bytes>{}({ candidates_hash_start, candidates_hash_size });
-            if (auto & cache_hit2 = candidates_memos.find(candidates_hash); cache_hit2 != candidates_memos.end()) {
+            if (auto cache_hit2 = candidates_memos.find(candidates_hash); cache_hit2 != candidates_memos.end()) {
                 return cache_hit2->second;
             } else {
                 cache_target = &(candidates_memos[candidates_hash]);

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -28,6 +28,14 @@ struct std::hash<bytes>
     }
 };
 
+using candidates_memos = std::unordered_map<size_t, llama_grammar_candidates>;
+using stack_memos = std::unordered_map<size_t, candidates_memos>;
+static stack_memos memo_cache;
+
+static void llama_grammar_reset_memos() {
+    memo_cache.clear();
+}
+
 // NOTE: assumes valid utf8 (but checks for overrun)
 static std::pair<uint32_t, const char *> decode_utf8(const char * src) {
     static const int lookup[] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 4 };
@@ -880,11 +888,6 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
         }
         return rejects;
     }
-    
-    
-    using candidates_memos = std::unordered_map<size_t, llama_grammar_candidates>;
-    using stack_memos = std::unordered_map<size_t, candidates_memos>;
-    static stack_memos memo_cache;
     
     auto stack_hash_start = reinterpret_cast<const char *>(stack.data());
     auto stack_hash_size  = sizeof(stack[0]) * stack.size();

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -8,9 +8,25 @@
 #include <algorithm>
 #include <stdexcept>
 
+#include <iostream>
+#include <string_view>
+#include <unordered_set>
+
 //
 // helpers
 //
+
+using bytes = std::pair<const char*, size_t>;
+using hash_entry_size = std::pair<size_t, size_t>;
+
+template <>
+struct std::hash<bytes>
+{
+    std::size_t operator()(const bytes& x) const noexcept
+    {
+        return std::hash<std::string_view>{}({x.first, x.second});
+    }
+};
 
 // NOTE: assumes valid utf8 (but checks for overrun)
 static std::pair<uint32_t, const char *> decode_utf8(const char * src) {
@@ -864,6 +880,40 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
         }
         return rejects;
     }
+    
+    
+    using candidates_memos = std::unordered_map<size_t, llama_grammar_candidates>;
+    using stack_memos = std::unordered_map<size_t, candidates_memos>;
+    static stack_memos memo_cache;
+    
+    auto stack_hash_start = reinterpret_cast<const char *>(stack.data());
+    auto stack_hash_size  = sizeof(stack[0]) * stack.size();
+    auto stack_hash       = std::hash<bytes>{}({ stack_hash_start, stack_hash_size });
+
+    llama_grammar_candidates* cache_target = nullptr;
+    
+    // Only check stash hash first - these are usually ~24b, and almost always under 64b
+    if (auto& cache_hit = memo_cache.find(stack_hash); cache_hit != memo_cache.end()) {
+        // Only attempt to memoize candidate lists under 1280
+        // >75% of candidate lists are under 1280 and 50% are under 640b. Most 'problem' loops are under 24b
+        // However, candidate lists can be over 72k, so we need to limit our checks
+        auto candidates_hash_size  = sizeof(candidates[0]) * candidates.size();
+        if (candidates_hash_size < 1280) {
+            auto& candidates_memos = cache_hit->second;
+            auto candidates_hash_start = reinterpret_cast<const char *>(candidates.data());
+            auto candidates_hash       = std::hash<bytes>{}({ candidates_hash_start, candidates_hash_size });
+            if (auto& cache_hit2 = candidates_memos.find(candidates_hash); cache_hit2 != candidates_memos.end()) {
+                return cache_hit2->second;
+            }
+            else {
+                cache_target = &(candidates_memos[candidates_hash]);
+            }
+        }
+    }
+    else {
+        memo_cache[stack_hash];
+    }
+
 
     const llama_grammar_element * stack_pos = stack.back();
 
@@ -900,6 +950,9 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
         rejects.push_back({ tok.index, tok.code_points - 1, tok.partial_utf8 });
     }
 
+    if (cache_target) {
+        *cache_target = rejects;
+    }
     return rejects;
 }
 


### PR DESCRIPTION
This adds a memoized data cache to `llama_grammar_reject_candidates_for_stack`
1. The cache first checks the stack as this is reasonable small check since stacks are usually between 20-60 bytes.
2. If the stack is a hit, it checks the current candidate list size.
  - Candidate list sizes vary greatly. 50% are ~600b or below, 75% below 1280b, but they max out around 72k
  - Most 'problematic' recursion happens with lists of ~24b.
  a. If the candidate list is <1280b, it's also checked for cache hit to return early
  b. If this wasn't a hit - the result of the function is cached

This change completely eliminates 'hangs' from branching explosions in complex grammar in all my tests so far, as well as speeding up 'heavy' grammar processing to run at nearly the same speed as no grammar at all.