### PR TITLE
remove obsolete warning about flash attention on Vulkan

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -6911,8 +6911,6 @@ def kcpp_main_process(launch_args, g_memory=None, gui_launcher=False):
 
         if not args.blasthreads or args.blasthreads <= 0:
             args.blasthreads = args.threads
-        if args.flashattention and (args.usevulkan is not None) and args.gpulayers!=0:
-            print("\nWARNING: FlashAttention is strongly discouraged when using Vulkan GPU offload as it is extremely slow!\n")
 
         modelname = os.path.abspath(args.model_param)
         print(args)


### PR DESCRIPTION
IIRC, it wasn't implemented on ggml, so it used to fall back to CPU inference. The current implementation _is_ a bit slower on most cards (~5% drop on my old 3400G), but it can be a little bit faster in some cases (https://github.com/ggml-org/llama.cpp/discussions/10879).