### PR TITLE
AutoGuess: Move Generic cases to end of file and put Kimi with other ChatML variants

### DIFF
--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -24,15 +24,15 @@
         "tools_end": "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n"
     }
 }, {
-    "search": ["<|im_start|>assistant", "<|im_end|>"],
-    "name": "ChatML (Generic).",
+    "search": ["<|im_start|>assistant<|im_middle|>", "<|im_assistant|>assistant<|im_middle|>", "<|im_end|>"],
+    "name": "ChatML (Kimi).",
     "adapter": {
-        "system_start": "<|im_start|>system\n",
-        "system_end": "<|im_end|>\n",
-        "user_start": "<|im_start|>user\n",
-        "user_end": "<|im_end|>\n",
-        "assistant_start": "<|im_start|>assistant\n",
-        "assistant_end": "<|im_end|>\n"
+        "system_start": "<|im_start|>system<|im_middle|>",
+        "system_end": "<|im_end|>",
+        "user_start": "<|im_start|>user<|im_middle|>",
+        "user_end": "<|im_end|>",
+        "assistant_start": "<|im_start|>assistant<|im_middle|>",
+        "assistant_end": "<|im_end|>"
     }
 }, {
     "search": ["System role not supported", "<start_of_turn>"],
@@ -112,17 +112,6 @@
         "assistant_end": "</s>"
     }
 }, {
-    "search": ["[/INST]"],
-    "name": "Mistral (Generic)",
-    "adapter": {
-        "system_start": "[INST]",
-        "system_end": "[/INST]\n",
-        "user_start": "[INST]",
-        "user_end": "",
-        "assistant_start": "[/INST]\n",
-        "assistant_end": "</s>"
-    }
-}, {
     "search": ["[gMASK]<sop>"],
     "name": "GLM-4",
     "adapter": {
@@ -189,17 +178,6 @@
         "assistant_end": "<|eom|>"
     }
 }, {
-    "search": ["<|im_start|>assistant<|im_middle|>", "<|im_assistant|>assistant<|im_middle|>", "<|im_end|>"],
-    "name": "ChatML (Kimi).",
-    "adapter": {
-        "system_start": "<|im_start|>system<|im_middle|>",
-        "system_end": "<|im_end|>",
-        "user_start": "<|im_start|>user<|im_middle|>",
-        "user_end": "<|im_end|>",
-        "assistant_start": "<|im_start|>assistant<|im_middle|>",
-        "assistant_end": "<|im_end|>"
-    }
-}, {
     "search": ["<|userprompt|>", "<|endofuserprompt|>", "<|response|>", "<|endofresponse|>"],
     "name": "Dots",
     "adapter": {
@@ -220,6 +198,32 @@
         "user_end": "\n",
         "assistant_start": "ASSISTANT: ",
         "assistant_end": "</s>\n"
+    }
+},
+
+
+
+{
+    "search": ["[/INST]"],
+    "name": "Mistral (Generic)",
+    "adapter": {
+        "system_start": "[INST]",
+        "system_end": "[/INST]\n",
+        "user_start": "[INST]",
+        "user_end": "",
+        "assistant_start": "[/INST]\n",
+        "assistant_end": "</s>"
+    }
+}, {
+    "search": ["<|im_start|>assistant", "<|im_end|>"],
+    "name": "ChatML (Generic).",
+    "adapter": {
+        "system_start": "<|im_start|>system\n",
+        "system_end": "<|im_end|>\n",
+        "user_start": "<|im_start|>user\n",
+        "user_end": "<|im_end|>\n",
+        "assistant_start": "<|im_start|>assistant\n",
+        "assistant_end": "<|im_end|>\n"
     }
 }
 ]

--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -24,14 +24,14 @@
         "tools_end": "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n"
     }
 }, {
-    "search": ["<|im_start|>assistant<|im_middle|>", "<|im_assistant|>assistant<|im_middle|>", "<|im_end|>"],
+    "search": ["<|im_user|>user<|im_middle|>", "<|im_assistant|>assistant<|im_middle|>", "<|im_end|>"],
     "name": "ChatML (Kimi).",
     "adapter": {
-        "system_start": "<|im_start|>system<|im_middle|>",
+        "system_start": "<|im_system|>system<|im_middle|>",
         "system_end": "<|im_end|>",
-        "user_start": "<|im_start|>user<|im_middle|>",
+        "user_start": "<|im_user|>user<|im_middle|>",
         "user_end": "<|im_end|>",
-        "assistant_start": "<|im_start|>assistant<|im_middle|>",
+        "assistant_start": "<|im_assistant|>assistant<|im_middle|>",
         "assistant_end": "<|im_end|>"
     }
 }, {


### PR DESCRIPTION
Looking at the code, this *looks* necessary (ordering).

To avoid issues like this, I moved the generic ones (currently two - mistral and chatml) to the bottom, with some newlines before them as delimiter.