### PR TITLE
fix unintended sd model quantization

### DIFF
--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -35,6 +35,9 @@
 // #define STB_IMAGE_RESIZE_IMPLEMENTATION //already defined in llava
 #include "stb_image_resize.h"
 
+static_assert((int)SD_TYPE_COUNT == (int)GGML_TYPE_COUNT,
+              "inconsistency between SD_TYPE_COUNT and GGML_TYPE_COUNT");
+
 enum SDMode {
     TXT2IMG,
     IMG2IMG,

--- a/otherarch/sdcpp/stable-diffusion.h
+++ b/otherarch/sdcpp/stable-diffusion.h
@@ -100,7 +100,7 @@ enum sd_type_t {
     SD_TYPE_IQ4_NL_4_4 = 36,
     // SD_TYPE_IQ4_NL_4_8 = 37,
     // SD_TYPE_IQ4_NL_8_8 = 38,
-    SD_TYPE_COUNT   = 39,
+    SD_TYPE_COUNT   = 40,
 };
 
 SD_API const char* sd_type_name(enum sd_type_t type);


### PR DESCRIPTION
The recent ggml update added another quant type, GGML_TYPE_MXFP4, which got the same value as SD_TYPE_COUNT. That made the embedded sd.cpp quantize to GGML_TYPE_MXFP4 by default.

Photomaker in particular ends up crashing due to "Missing CPY op for types: f32 mxfp4".

Related: https://github.com/leejet/stable-diffusion.cpp/pull/760