### PR TITLE
tweak OpenAI Harmony autoguess developer prefix and assistant end token

### DIFF
--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -190,7 +190,7 @@
     "search": ["<|start|>user<|message|>", "<|channel|>", "<|end|>"],
     "name": "OpenAI Harmony",
     "adapter": {
-        "system_start": "<|start|>developer<|message|>",
+        "system_start": "<|start|>developer<|message|># Instructions\n\n",
         "system_end": "<|end|>",
         "user_start": "<|start|>user<|message|>",
         "user_end": "<|end|>",

--- a/kcpp_adapters/AutoGuess.json
+++ b/kcpp_adapters/AutoGuess.json
@@ -195,7 +195,7 @@
         "user_start": "<|start|>user<|message|>",
         "user_end": "<|end|>",
         "assistant_start": "<|start|>assistant<|channel|>final<|message|>",
-        "assistant_end": "<|return|>"
+        "assistant_end": "<|end|>"
     }
 }, {
     "search": ["rwkv_", "'User: '"],


### PR DESCRIPTION
1. The system message needs an `# Instructions\n\n` prefix.
2. The adapter_end `<|return|>` token is used for training, and we want to use `<|end|>` for the generic case. See details below.

The .jinja template has this:
```jinja
{#- Render developer message #}
{%- if developer_message or tools %}
    {{- "<|start|>developer<|message|>" }}
    {%- if developer_message %}
        {{- "# Instructions\n\n" }}
        {{- developer_message }}
    {%- endif %}
    {%- if tools -%}
        {{- "\n\n" }}
        {{- "# Tools\n\n" }}
        {{- render_tool_namespace("functions", tools) }}
    {%- endif -%}
    {{- "<|end|>" }}
{%- endif %}
```
i.e. it prefixes the developer (system) message with `# Instructions\n\n`.

(Caught in #1659, but pushing as a separate PR as I don't know if that PR will survive.)

Edit: after re-running the test, I'm also seeing this
```
OpenAI Harmony                 = OpenAI Harmony                 : missing expected fragment
	adapter:  <|start|>assistant<|channel|>final<|message|>asst_1<|return|>
	tokenizer: <|start|>assistant<|channel|>final<|message|>asst_1<|end|><|start|>user<|message|>user_2<|end|> openai/gpt-oss-120b                         
```
which indicates the assistant end prefix should be `<|end|>` and not `<|return|>`. I'm not clear on the difference atm.

For `[{"role":"developer","content":"hi"},{"role":"user","content":"hello"},{"role":"assistant","content":"e"},{"role":"user","content":"o"}]`, the chat template outputs (with `add_generation_prompt=True`):
```
('<|start|>system<|message|>You are ChatGPT, a large language model trained by '
 'OpenAI.\n'
 'Knowledge cutoff: 2024-06\n'
 'Current date: 2025-08-08\n'
 '\n'
 'Reasoning: medium\n'
 '\n'
 '# Valid channels: analysis, commentary, final. Channel must be included for '
 'every message.<|end|><|start|>developer<|message|># Instructions\n'
 '\n'
 '1\n'
 '<|end|><|start|>user<|message|>2\n'
 '<|end|><|start|>assistant<|channel|>final<|message|>3\n'
 '<|end|><|start|>user<|message|>4\n'
 '<|end|><|start|>assistant<|channel|>final<|message|>5\n'
 '<|end|><|start|>user<|message|>6\n'
 '<|end|><|start|>assistant')
>>> 
```
(`add_generation_prompt=False`):
```
('<|start|>system<|message|>You are ChatGPT, a large language model trained by '
 'OpenAI.\n'
 'Knowledge cutoff: 2024-06\n'
 'Current date: 2025-08-08\n'
 '\n'
 'Reasoning: medium\n'
 '\n'
 '# Valid channels: analysis, commentary, final. Channel must be included for '
 'every message.<|end|><|start|>developer<|message|># Instructions\n'
 '\n'
 '1\n'
 '<|end|><|start|>user<|message|>2\n'
 '<|end|><|start|>assistant<|channel|>final<|message|>3\n'
 '<|end|><|start|>user<|message|>4\n'
 '<|end|><|start|>assistant<|channel|>final<|message|>5\n'
 '<|end|><|start|>user<|message|>6\n'
 '<|end|>')
```

A-HA! This thing is specifically for training: when the assistant is the last role and there is no add_generation_prompt, it assumes you are generating training examples, and it uses `<|return|>` instead of `<|end|>`, as described in
```
        {%- elif loop.last and not add_generation_prompt %}
            {#- Only render the CoT if the final turn is an assistant turn and add_generation_prompt is false #}
            {#- This is a situation that should only occur in training, never in inference. #}
            {%- if "thinking" in message %}
                {{- "<|start|>assistant<|channel|>analysis<|message|>" + message.thinking + "<|end|>" }}
            {%- endif %}
            {#- <|return|> indicates the end of generation, but <|end|> does not #}
            {#- <|return|> should never be an input to the model, but we include it as the final token #}
            {#- when training, so the model learns to emit it. #}
            {{- "<|start|>assistant<|channel|>final<|message|>" + message.content + "<|return|>" }}
```
-- the above with the last user turn removed and `add_generation_prompt=False`:
```
('<|start|>system<|message|>You are ChatGPT, a large language model trained by '
 'OpenAI.\n'
 'Knowledge cutoff: 2024-06\n'
 'Current date: 2025-08-08\n'
 '\n'
 'Reasoning: medium\n'
 '\n'
 '# Valid channels: analysis, commentary, final. Channel must be included for '
 'every message.<|end|><|start|>developer<|message|># Instructions\n'
 '\n'
 '1\n'
 '<|end|><|start|>user<|message|>2\n'
 '<|end|><|start|>assistant<|channel|>final<|message|>3\n'
 '<|end|><|start|>user<|message|>4\n'
 '<|end|><|start|>assistant<|channel|>final<|message|>5\n'
 '<|return|>')
```

Nifty. But it does mean the adapter should use `<|end|>`, I'd say. 