### PR TITLE
speed up kcpp version checking

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -8,6 +8,15 @@
 # editing tools, save formats, memory, world info, author's note, characters,
 # scenarios and everything Kobold and KoboldAI Lite have to offer.
 
+# Version constant
+KcppVersion = "1.97.4"
+
+# Quick version check before any heavy imports
+import sys
+if len(sys.argv) == 2 and sys.argv[1] in ["--version", "-v", "-V"]:
+    print(KcppVersion)
+    sys.exit(0)
+
 import os
 try:
     os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID" # try set GPU to PCI order first thing
@@ -63,7 +72,6 @@ dry_seq_break_max = 128
 extra_images_max = 4
 
 # global vars
-KcppVersion = "1.97.4"
 showdebug = True
 kcpp_instance = None #global running instance
 global_memory = {"tunnel_url": "", "restart_target":"", "input_to_exit":False, "load_complete":False, "restart_override_config_target":""}
@@ -6487,10 +6495,6 @@ def unregister_koboldcpp():
 def main(launch_args, default_args):
     global args, showdebug, kcpp_instance, exitcounter, using_gui_launcher, sslvalid, global_memory
     args = launch_args #note: these are NOT shared with the child processes!
-
-    if (args.version) and len(sys.argv) <= 2:
-        print(f"{KcppVersion}") # just print version and exit
-        return
 
     #prevent disallowed combos
     if (args.nomodel or args.benchmark or args.launch or args.admin) and args.cli:

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -13,7 +13,7 @@ KcppVersion = "1.97.4"
 
 # Quick version check before any heavy imports
 import sys
-if len(sys.argv) == 2 and sys.argv[1] in ["--version", "-v", "-V"]:
+if len(sys.argv) == 2 and sys.argv[1] == "--version":
     print(KcppVersion)
     sys.exit(0)
 


### PR DESCRIPTION
This is a minor change meant to increase the performance of calling the CLI with the "--version" argument. In this case, the user is not expecting to run the app and merely wants to know the version. Currently this check takes relatively long to resolve because python needs to import a large list of very heavy modules first. By putting the version check at the top of the file, we're greatly reducing the response time of version checks by skipping all the heavy imports.