### PR TITLE
Force disabling debug in quiet mode for image gen

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1666,6 +1666,8 @@ def sd_load_model(model_filename,vae_filename,lora_filename,t5xxl_filename,clipl
     inputs.img_hard_limit = args.sdclamped
     inputs.img_soft_limit = args.sdclampedsoft
     inputs = set_backend_props(inputs)
+    if args.quiet:
+        inputs.debugmode = 0
     ret = handle.sd_load_model(inputs)
     return ret
 


### PR DESCRIPTION
Debug messages for prompt processing currently ignore the quiet flag:

```
txt2img 512x512
prompt after extract and remove lora: "a beautiful landscape" apply_loras completed, taking 0.00s
parse 'a beautiful landscape' to [['a beautiful landscape', 1], ] token length: 77
```