### PR TITLE
llguidance: update makefile to clone llguidance if the flag is enabled and the directory does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,9 @@ CFLAGS += -DLLAMA_USE_LLGUIDANCE
 CXXFLAGS += -DLLAMA_USE_LLGUIDANCE
 LDFLAGS  += -Lllguidance/target/release -lllguidance
 OBJS_FULL += llguidance.o
-llguidance.o: common/llguidance.cpp
+llguidance:
+	git clone --depth=1 --branch v1.2.0 https://github.com/guidance-ai/llguidance.git
+llguidance.o: common/llguidance.cpp llguidance
 	cd llguidance && cargo build --release
 	$(CXX) $(CXXFLAGS) -Illguidance/target/release -c $< -o $@
 endif
@@ -729,6 +731,7 @@ clean:
 	rm -vf *.o main ttsmain sdmain whispermain quantize_gguf quantize_clip quantize_gpt2 quantize_gptj quantize_neox quantize_mpt vulkan-shaders-gen vulkan-shaders-gen-noext gguf-split mtmd-cli mainvk mainvk.exe mtmd-cli.exe gguf-split.exe vulkan-shaders-gen.exe vulkan-shaders-gen-noext.exe main.exe ttsmain.exe sdmain.exe whispermain.exe quantize_clip.exe quantize_gguf.exe quantize_gptj.exe quantize_gpt2.exe quantize_neox.exe quantize_mpt.exe koboldcpp_default.dll koboldcpp_failsafe.dll koboldcpp_noavx2.dll koboldcpp_clblast.dll koboldcpp_clblast_noavx2.dll koboldcpp_clblast_failsafe.dll koboldcpp_cublas.dll koboldcpp_hipblas.dll koboldcpp_vulkan.dll koboldcpp_vulkan_noavx2.dll koboldcpp_default.so koboldcpp_failsafe.so koboldcpp_noavx2.so koboldcpp_clblast.so koboldcpp_clblast_noavx2.so koboldcpp_clblast_failsafe.so koboldcpp_cublas.so koboldcpp_hipblas.so koboldcpp_vulkan.so koboldcpp_vulkan_noavx2.so ggml/src/ggml-vulkan-shaders.cpp ggml/src/ggml-vulkan-shaders.hpp ggml/src/ggml-vulkan-shaders-noext.cpp ggml/src/ggml-vulkan-shaders-noext.hpp
 	rm -vrf ggml/src/ggml-cuda/*.o
 	rm -vrf ggml/src/ggml-cuda/template-instances/*.o
+	rm -vrf llguidance
 
 # useful tools
 main: tools/main/main.cpp common/arg.cpp build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o console.o llavaclip_default.o llava.o ggml-backend_default.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)


### PR DESCRIPTION
I forgot to add this in when removing the submodule.

Also remove llguidance when running 'make clean'