### PR TITLE
Mirostat: Tau + Eta Swap Toggle

### DIFF
--- a/expose.h
+++ b/expose.h
@@ -105,6 +105,7 @@ struct generation_inputs
     const int mirostat = 0;
     const float mirostat_eta = 0.0f;
     const float mirostat_tau = 0.0f;
+    const float mirostat_swap = 0;
     const float xtc_threshold = 0.0f;
     const float xtc_probability = 0.0f;
     const samplers sampler_order[KCPP_SAMPLER_MAX] = {};

--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -1644,7 +1644,7 @@ void sample_guidance(struct llama_context * ctx, struct llama_context * guidance
 }
 
 int SampleLogits(const float * logits, int n_ctx, int n_vocab, int rep_pen_range, float rep_pen, float rep_pen_slope, float presence_penalty, float top_k, float top_a, float top_p, float min_p, float typical_p, float tfs, float nsigma, float temp, std::mt19937 & rng,
-int mirostat, float mirostat_tau, float mirostat_eta, float dry_multiplier, float dry_base, int dry_allowed_length, int dry_penalty_last_n, float xtc_threshold, float xtc_probability,
+int mirostat, float mirostat_tau, float mirostat_eta, int mirostat_swap, float dry_multiplier, float dry_base, int dry_allowed_length, int dry_penalty_last_n, float xtc_threshold, float xtc_probability,
 const std::vector<samplers> & sampler_order, llama_grammar * grammar, float dynatemp_range, float dynatemp_exponent, float smoothing_factor)
 {
     // printf("SampleLogits called with: n_ctx=%d, n_vocab=%d, rep_pen_range=%d, rep_pen=%f, rep_pen_slope=%f, presence_penalty=%f, top_k=%f, top_a=%f, top_p=%f, min_p=%f, typical_p=%f, tfs=%f, nsigma=%f, temp=%f, mirostat=%d, mirostat_tau=%f, mirostat_eta=%f, dry_multiplier=%f, dry_base=%f, dry_allowed_length=%d, dry_penalty_last_n=%d, xtc_threshold=%f, xtc_probability=%f, sampler_order_size=%zu, dynatemp_range=%f, dynatemp_exponent=%f, smoothing_factor=%f\n",
@@ -1692,11 +1692,19 @@ const std::vector<samplers> & sampler_order, llama_grammar * grammar, float dyna
         sample_temperature(&candidates_p, temp, smoothing_factor);
         if (mirostat == 1)
         {
-            id = sample_token_mirostat(n_vocab, &candidates_p, rng, mirostat_tau, mirostat_eta, mirostat_m, &mirostat_mu);
+            if (mirostat_swap == 1) {
+                id = sample_token_mirostat(n_vocab, &candidates_p, rng, mirostat_tau, mirostat_eta, mirostat_m, &mirostat_mu);
+            } else {
+                id = sample_token_mirostat(n_vocab, &candidates_p, rng, mirostat_eta, mirostat_tau, mirostat_m, &mirostat_mu);
+            }
         }
         else
         {
-            id = sample_token_mirostat_v2(&candidates_p, rng, mirostat_tau, mirostat_eta, &mirostat_mu);
+            if (mirostat_swap == 1) {
+                id = sample_token_mirostat_v2(&candidates_p, rng, mirostat_tau, mirostat_eta, &mirostat_mu);
+            } else {
+                id = sample_token_mirostat_v2(&candidates_p, rng, mirostat_eta, mirostat_tau, &mirostat_mu);
+            }
         }
     }
     else
@@ -3427,6 +3435,7 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
     kcpp_data->mirostat = inputs.mirostat;
     kcpp_data->mirostat_eta = inputs.mirostat_eta;
     kcpp_data->mirostat_tau = inputs.mirostat_tau;
+    kcpp_data->mirostat_swap = inputs.mirostat_swap;
     kcpp_data->dry_multiplier = inputs.dry_multiplier;
     kcpp_data->dry_base = inputs.dry_base;
     kcpp_data->dry_allowed_length = inputs.dry_allowed_length;
@@ -4213,7 +4222,7 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
 
                 id = SampleLogits(logitsPtr, nctx, n_vocab, last_n_size, repeat_penalty, kcpp_data->rep_pen_slope, presence_penalty,
                 top_k, top_a, top_p, min_p, typical_p, tfs_z, nsigma, temp, rng,
-                kcpp_data->mirostat, kcpp_data->mirostat_tau, kcpp_data->mirostat_eta,
+                kcpp_data->mirostat, kcpp_data->mirostat_tau, kcpp_data->mirostat_eta, kcpp_data->mirostat_swap,
                 kcpp_data->dry_multiplier, kcpp_data->dry_base,
                 kcpp_data->dry_allowed_length, kcpp_data->dry_penalty_last_n, kcpp_data->xtc_threshold, kcpp_data->xtc_probability,
                 sampler_order, grammar, dynatemp_range, dynatemp_exponent, smoothing_factor);

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -240,6 +240,7 @@ class generation_inputs(ctypes.Structure):
                 ("mirostat", ctypes.c_int),
                 ("mirostat_tau", ctypes.c_float),
                 ("mirostat_eta", ctypes.c_float),
+                ("mirostat_swap", ctypes.c_int),
                 ("xtc_threshold", ctypes.c_float),
                 ("xtc_probability", ctypes.c_float),
                 ("sampler_order", ctypes.c_int * sampler_order_max),
@@ -1495,6 +1496,7 @@ def generate(genparams, stream_flag=False):
     mirostat = tryparseint(genparams.get('mirostat', 0),0)
     mirostat_tau = tryparsefloat(genparams.get('mirostat_tau', 5.0),5.0)
     mirostat_eta = tryparsefloat(genparams.get('mirostat_eta', 0.1),0.1)
+    mirostat_swap = tryparseint(genparams.get('mirostat_swap', 1),1)
     dry_multiplier = tryparsefloat(genparams.get('dry_multiplier', 0.0),0.0)
     dry_base = tryparsefloat(genparams.get('dry_base', 1.75),1.75)
     dry_allowed_length = tryparseint(genparams.get('dry_allowed_length', 2),2)
@@ -1594,8 +1596,9 @@ def generate(genparams, stream_flag=False):
         inputs.mirostat = mirostat
         inputs.mirostat_tau = mirostat_tau
         inputs.mirostat_eta = mirostat_eta
+        inputs.mirostat_swap = mirostat_swap
     else:
-        inputs.mirostat = inputs.mirostat_tau = inputs.mirostat_eta = 0
+        inputs.mirostat = inputs.mirostat_tau = inputs.mirostat_eta = inputs.mirostat_swap = 0
     inputs.dry_multiplier = dry_multiplier
     inputs.dry_base = dry_base
     inputs.xtc_threshold = xtc_threshold

--- a/otherarch/otherarch.h
+++ b/otherarch/otherarch.h
@@ -40,6 +40,7 @@ struct kcpp_params {
     int32_t mirostat          = 0;     // 0 = disabled, 1 = mirostat, 2 = mirostat 2.0
     float   mirostat_tau      = 5.00f; // target entropy
     float   mirostat_eta      = 0.10f; // learning rate
+    int32_t mirostat_swap     = 1;     // 0 = disabled, 1 = swapped tau + eta
     float   dry_multiplier    = 0.0f;  // penalty multiplier, 0.0 = disabled
     float   dry_base          = 1.75f; // exponential base
     int32_t dry_allowed_length = 2;    // repeated sequences longer than this are penalized


### PR DESCRIPTION
Yup. Taking a multi-year long KCPP bug that flew under the radar and turning it into a feature.

As it turns out, the bug LostRuins left when adding the sampler ended up making it not only give better performance for creative writing, but also the potential for better compatibility with other samplers.

The bug also allows using more *absurd* values as apposed to the standard `0.05`-`0.2` for eta, and `0.4`-`1.0` for tau, which has interesting effects on writing style, but I'm sure those of you who used KCPP extensively already knew that.

`mirostat_swap: 1` uses the KCPP method (swapped tau and eta) and is the sampler's default value.
`mirostat_swap: 0` uses the standard method.