### PR TITLE
sd: prevent build errors due to the GGML_KQ_MASK_PAD removal

### DIFF
--- a/otherarch/sdcpp/ggml_extend.hpp
+++ b/otherarch/sdcpp/ggml_extend.hpp
@@ -1274,6 +1274,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_attention_ext(struct ggml_context
         }
 
         if (mask_in != nullptr) {
+            #ifdef GGML_KQ_MASK_PAD
             int mask_pad = 0;
             if (mask_in->ne[1] % GGML_KQ_MASK_PAD != 0) {
                 mask_pad = GGML_PAD(L_q, GGML_KQ_MASK_PAD) - mask_in->ne[1];
@@ -1281,6 +1282,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_attention_ext(struct ggml_context
             if (mask_pad > 0) {
                 mask_in = ggml_pad(ctx, mask_in, 0, mask_pad, 0, 0);
             }
+            #endif
             mask_in = ggml_cast(ctx, mask_in, GGML_TYPE_F16);
         }
 


### PR DESCRIPTION
Removed on llama.cpp 4dff236 / ggml 4767bda . Tests with sd.cpp show this padding won't be needed anymore.