### PR TITLE
fix autofit_tax_mb type error

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1495,7 +1495,7 @@ def load_model(model_filename):
         inputs.quant_k = inputs.quant_v = 0
     inputs.batchsize = args.batchsize
     inputs.autofit = args.autofit
-    inputs.autofit_tax_mb = calulated_gpu_overhead
+    inputs.autofit_tax_mb = int(calulated_gpu_overhead)
     inputs.gpulayers = args.gpulayers
     if args.overridenativecontext and args.overridenativecontext>0:
         inputs.overridenativecontext = args.overridenativecontext


### PR DESCRIPTION
I'm getting:
```
  File "./koboldcpp.py", line 1498, in load_model
    inputs.autofit_tax_mb = calulated_gpu_overhead
    ^^^^^^^^^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
```