### PR TITLE
Add missing resolve_refs call to enable subschema use

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1089,6 +1089,7 @@ def convert_json_to_gbnf(json_obj):
         dotall=False,
         raw_pattern=False)
         schema = json.loads(json.dumps(json_obj))
+        schema = converter.resolve_refs(schema, '')
         converter.visit(schema, '')
         outstr = converter.format_grammar()
         return outstr


### PR DESCRIPTION
Trying to use JSON schema with subschema over API results in key error.
`JSON to GBNF failed: '#/$defs/foo'`

This is due to missing the initial `resolve_refs` call before `visit`.

This PR adds the missing call to resolve this issue.