### PR TITLE
fix: correct typos in codebase

### DIFF
--- a/common/ngram-map.cpp
+++ b/common/ngram-map.cpp
@@ -462,7 +462,7 @@ void common_ngram_map_draft(common_ngram_map & map,
             slot_max = v;
         }
     }
-    // What is sum of the other occurences?
+    // What is sum of the other occurrences?
     uint32_t sum_occur = 0;
     for (int v = 0; v < COMMON_NGRAM_MAX_VALUES; ++v) {
         if (v == slot_max) {

--- a/common/ngram-map.h
+++ b/common/ngram-map.h
@@ -45,7 +45,7 @@ llama_tokens common_ngram_simple_draft(
 // statistics of a m-gram after a known n-gram
 struct common_ngram_map_value {
     size_t   value_idx =  0;  // index of value m-gram in token-history (0 if unused)
-    uint16_t value_num =  0;  // number of occurences of this value m-gram after the key n-gram (0 in an unused values-slot)
+    uint16_t value_num =  0;  // number of occurrences of this value m-gram after the key n-gram (0 in an unused values-slot)
     int16_t n_accepted = -1;  // number of accepted tokens at last draft (-1 if unused)
 };
 
@@ -54,7 +54,7 @@ struct common_ngram_map_key {
     size_t   key_idx;   // index of key n-gram in token-history
     size_t   stat_idx;  // index of last token of stastistics computation (key_num, values)
 
-    uint16_t key_num;   // number of occurences of this key n-gram in token-history
+    uint16_t key_num;   // number of occurrences of this key n-gram in token-history
     common_ngram_map_value values[COMMON_NGRAM_MAX_VALUES]; // some known values after the key
 };
 

--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -2835,7 +2835,7 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
         printf("\nRWKV Vocab: %u\n", vocabsiz);
         logits.resize(vocabsiz);
 
-        n_vocab = vocab.id_to_token.size(); //handled seperately
+        n_vocab = vocab.id_to_token.size(); //handled separately
 
         if (file_format == FileFormat::RWKV_1)
         {

--- a/include/llama.h
+++ b/include/llama.h
@@ -485,7 +485,7 @@ extern "C" {
     enum llama_params_fit_status {
         LLAMA_PARAMS_FIT_STATUS_SUCCESS = 0, // found allocations that are projected to fit
         LLAMA_PARAMS_FIT_STATUS_FAILURE = 1, // could not find allocations that are projected to fit
-        LLAMA_PARAMS_FIT_STATUS_ERROR   = 2, // a hard error occured, e.g. because no model could be found at the specified path
+        LLAMA_PARAMS_FIT_STATUS_ERROR   = 2, // a hard error occurred, e.g. because no model could be found at the specified path
     };
 
     // fits mparams and cparams to free device memory (assumes system memory is unlimited)


### PR DESCRIPTION
Fixed several typos across the codebase:

- gpttype_adapter.cpp: 'seperately' → 'separately'
- include/llama.h: 'occured' → 'occurred'
- common/ngram-map.h: 'occurences' → 'occurrences' (2 places)
- common/ngram-map.cpp: 'occurences' → 'occurrences'