### PR TITLE
Fix for [THINK] token visibility / Ministral tokens workaround

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2505,11 +2505,12 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                         || t.first == "<|fim_prefix|>"  // Qwen
                         || t.first == "<fim-prefix>"
                         || t.first == "<fim_prefix>"    // Granite
-                        || t.first == "<｜fim▁begin｜>" // DeepSeek
+                        || t.first == "<｜fim▁begin｜>"  // DeepSeek
                         || t.first == "<PRE>"
                         || t.first == "▁<PRE>"          // CodeLlama
                         || t.first == "<|code_prefix|>" // GLM-4.5
                         || t.first == "<|prefix|>"      // Falcon-H1-Tiny-Coder
+                        || t.first == "[PREFIX]"        // Ministral 3
                         ) {
                     special_fim_pre_id = t.second;
                     if ((attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
@@ -2531,6 +2532,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                         || t.first == "▁<SUF>"         // CodeLlama
                         || t.first == "<|code_suffix|>" // GLM-4.5
                         || t.first == "<|suffix|>"      // Falcon-H1-Tiny-Coder
+                        || t.first == "[SUFFIX]"        // Ministral 3
                         ) {
                     special_fim_suf_id = t.second;
                     if ((attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
@@ -2552,6 +2554,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                         || t.first == "▁<MID>"         // CodeLlama
                         || t.first == "<|code_middle|>" // GLM-4.5
                         || t.first == "<|middle|>"      // Falcon-H1-Tiny-Coder
+                        || t.first == "[MIDDLE]"        // Ministral 3
                         ) {
                     special_fim_mid_id = t.second;
                     if ((attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
@@ -2695,13 +2698,32 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
         }
 
         // @ngxson : quick hack for gpt-oss, always render these tokens
+        // Now for Ministral 3 too
         for (const auto & t : token_to_id) {
             auto & attr = id_to_token[t.second].attr;
 
-            if (t.first == "<|channel|>" || t.first == "<|message|>" || t.first == "<|start|>" || t.first == "<|constrain|>") {
+            if (t.first == "<|channel|>"
+                || t.first == "<|message|>"
+                || t.first == "<|start|>"
+                || t.first == "<|constrain|>"
+            ) {
                 LLAMA_LOG_WARN("%s: setting token '%s' (%d) attribute to USER_DEFINED (%u), old attributes: %u\n",
                         __func__, t.first.c_str(), t.second, LLAMA_TOKEN_ATTR_USER_DEFINED, attr);
 
+                attr = LLAMA_TOKEN_ATTR_USER_DEFINED;
+            }
+
+            if(t.first == "[THINK]" // Mistral tokens
+                || t.first == "[/THINK]"
+                // I've added these because kobold doesn't support custom style tool calls
+                // So I think we should expose them to the caller as well
+                || t.first == "[CALL_ID]"
+                || t.first == "[TOOL_CONTENT]"
+                || t.first == "[TOOL_CALLS]"
+                || t.first == "[ARGS]"
+            ) {
+                 LLAMA_LOG_WARN("%s: setting token '%s' (%d) attribute to USER_DEFINED (%u), old attributes: %u\n",
+                        __func__, t.first.c_str(), t.second, LLAMA_TOKEN_ATTR_USER_DEFINED, attr);
                 attr = LLAMA_TOKEN_ATTR_USER_DEFINED;
             }
         }


### PR DESCRIPTION
So I'm not a C++ dev, but satisfied with the results.
1. I tried to set tokens as `USER_DEFINED`, but it removes them from generation probabilities entirely.
2. Setting them as `NORMAL` causes the BPE tokenizer to split them (eg [THINK] became '[TH' 'INK' ']' instead of 34), breaking the model's logic.

So I
- Set the token attribute to `LLAMA_TOKEN_ATTR_NORMAL` to ensure they are visible and available for sampling.
- Forcefully injected these specific IDs into the `special_tokens_cache`.

## Validation:
Tested with Ministral 8B 2512. The model now correctly predicts the single IDs 34/35 with 100% probability, and the tags are correctly rendered in the output stream.

I tested it with my model, and it now correctly uses [THINK] and [/THINK] tokens, and they're parsed as tokens too:
```
[Debug: Dump 160 Raw Input Tokens]
'<s> (1)', '[SYSTEM_PROMPT] (17)', ..., >> '[THINK] (34)' <<, ..., >> '[/THINK] (35)' <<, ...
```

Response:
```
Processing Prompt (17 / 17 tokens)
Generating (1 / 1000 tokens) [([THINK] <34> 100.00%)] <<
Generating (2 / 1000 tokens) [(\n <1010> 95.07%) ( Al 2.67%) (Okay 2.27%)]
Generating (3 / 1000 tokens) [(Okay <44053> 30.03%) (Al 38.88%) (The 31.09%)]
Generating (4 / 1000 tokens) [(, <1044> 100.00%)]
Generating (5 / 1000 tokens) [( the <1278> 100.00%)]
Generating (6 / 1000 tokens) [( user <3330> 100.00%)]
...
Generating (705 / 1000 tokens) [([/THINK] <35> 100.00%)] <<
```

```
Prompt:
Hi, can you test your reasoning.
Can you answer very shorty, why sky is blue?

Response:
<I cutted out the reasoning>
Blue light scatters most when hitting air molecules, making the sky appear blue.
```

I'm aware that the root cause is that Mistral set the attributes for these tokens as "special" in the base model, but I doubt they'll retrain their models since they're already widely distributed, so this workaround restores the intended functionality.

Linked issue: #1745 