### PR TITLE
Update ace-qwen3.cpp to build on MSVC

### DIFF
--- a/otherarch/acestep/ace-qwen3.cpp
+++ b/otherarch/acestep/ace-qwen3.cpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <unordered_map>
 #include <iomanip>
+#include <sstream>
 
 // Timer
 struct Timer {


### PR DESCRIPTION
need to include `<sstream>` otherwise build fails with lots of the below errors: 

```
C:\koboldcpp\otherarch\acestep\ace-qwen3.cpp(1278,9): error C2297: '<<': not valid as right operand has type 'const cha
r [26]' [C:\koboldcpp\build\music_adapter.vcxproj]
  (compiling source file '../otherarch/acestep/music_adapter.cpp')

C:\koboldcpp\otherarch\acestep\ace-qwen3.cpp(1278,9): error C2679: binary '<<': no operator found which takes a right-h
and operand of type 'std::string' (or there is no acceptable conversion) [C:\koboldcpp\build\music_adapter.vcxproj]
  (compiling source file '../otherarch/acestep/music_adapter.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Tools\MSVC\14.50.35717\include\__msvc_int128.hpp(
  753,46):
      could be 'std::_Unsigned128 std::operator <<(const std::_Unsigned128 &,const std::_Base128 &) noexcept' [found us
  ing argument-dependent lookup]
          C:\koboldcpp\otherarch\acestep\ace-qwen3.cpp(1278,9):
          'std::_Unsigned128 std::operator <<(const std::_Unsigned128 &,const std::_Base128 &) noexcept': cannot conver
  t argument 2 from 'std::string' to 'const std::_Base128 &'
              C:\koboldcpp\otherarch\acestep\ace-qwen3.cpp(1278,57):
              Reason: cannot convert from 'std::string' to 'const std::_Base128'
              C:\koboldcpp\otherarch\acestep\ace-qwen3.cpp(1278,57):
              No user-defined-conversion operator available that can perform this conversion, or the operator cannot be
   called
```