### PR TITLE
fix: add hybrid model KV cache guards for Granite 4 compatibility

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -517,6 +517,33 @@ static void GetOverlappingTokenSequences(const std::string& str, std::unordered_
     }
 }
 
+// Safe wrapper for llama_memory_seq_rm that handles hybrid/recurrent models.
+// For hybrid models, partial range removal (p0 > 0) is not supported by
+// recurrent memory layers (they can't partially erase state).
+// This function falls back to a full memory clear when partial removal fails.
+static bool safe_memory_seq_rm(llama_context * ctx, llama_seq_id seq_id, llama_pos p0, llama_pos p1)
+{
+    if(ctx == nullptr) return true;
+    llama_memory_t mem = llama_get_memory(ctx);
+    bool result = llama_memory_seq_rm(mem, seq_id, p0, p1);
+    if(!result)
+    {
+        //Partial removal failed (likely a hybrid/recurrent model).
+        //For recurrent/hybrid models, partial state erasure is not possible.
+        //Fall back to a full clear so the model can re-process from scratch.
+        const llama_model * mdl = llama_get_model(ctx);
+        if(llama_model_is_recurrent(mdl) || llama_model_is_hybrid(mdl))
+        {
+            if(debugmode >= 1 && !is_quiet)
+            {
+                printf("\n[Hybrid/Recurrent model: partial seq_rm(%d,%d) failed, performing full memory clear]\n", p0, p1);
+            }
+            llama_memory_clear(mem, true);
+        }
+    }
+    return result;
+}
+
 // Function to convert a UTF-8 encoded string to lowercase
 static std::string toLowerCase(const std::string& str) {
     std::string result;
@@ -598,10 +625,10 @@ void ContextRewind(std::vector<int> &embd, std::vector<int> &current_context_tok
 
     if (file_format == FileFormat::GGUF_GENERIC)
     {
-        llama_memory_seq_rm(llama_get_memory(llama_ctx_v4), 0, n_past, -1);
+        safe_memory_seq_rm(llama_ctx_v4, 0, n_past, -1);
         if(draft_ctx)
         {
-            llama_memory_seq_rm(llama_get_memory(draft_ctx), 0, n_past, -1);
+            safe_memory_seq_rm(draft_ctx, 0, n_past, -1);
         }
     }
 
@@ -1975,6 +2002,20 @@ bool FullyContainedPrefix(std::vector<int> &sequence1, std::vector<int> &sequenc
 //returns true if contextshift is doable, executes it if dryrun is false
 bool DoContextShifting(llama_context * ctx, llama_context * draft_ctx, std::vector<int> &current_context_tokens, std::vector<int> &new_context_tokens, const int genamt, const int nctx, bool dryrun)
 {
+    //Guard: Context shifting must not be used with hybrid or recurrent models.
+    //Hybrid models (e.g. Granite 4) have recurrent/SSM layers whose state cannot be
+    //partially erased. The seq_rm and seq_add operations used below would fail or
+    //corrupt state on those layers.
+    if(!dryrun && ctx != nullptr)
+    {
+        const llama_model * mdl = llama_get_model(ctx);
+        if(llama_model_is_recurrent(mdl) || llama_model_is_hybrid(mdl))
+        {
+            printf("\nWARNING: Context shifting is not supported for recurrent/hybrid models! Skipping.\n");
+            return false;
+        }
+    }
+
     //scan from start old and new ctx, until first mismatch found, save as p0
     //check remaining old and new ctx for longest common subseq, which needs to be at 256 tokens
     //test: longest common subseq (LCQ) MUST start within 0 tokens from end of memory, otherwise purge fails
@@ -2028,11 +2069,11 @@ bool DoContextShifting(llama_context * ctx, llama_context * draft_ctx, std::vect
             {
                 //extract the unwanted tokens out from context and KV
                 int diff = found - trimstart;
-                llama_memory_seq_rm(llama_get_memory(ctx), 0, trimstart, trimstart + diff);
+                safe_memory_seq_rm(ctx, 0, trimstart, trimstart + diff);
                 llama_memory_seq_add(llama_get_memory(ctx), 0, trimstart + diff, -1, -diff);
                 if(draft_ctx)
                 {
-                    llama_memory_seq_rm(llama_get_memory(draft_ctx), 0, trimstart, trimstart + diff);
+                    safe_memory_seq_rm(draft_ctx, 0, trimstart, trimstart + diff);
                     llama_memory_seq_add(llama_get_memory(draft_ctx), 0, trimstart + diff, -1, -diff);
                 }
                 for (size_t i = trimstart + diff; i < current_context_tokens.size() - 1; i++)
@@ -2593,10 +2634,24 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
               //prepare savestate slots
         savestate_limit = inputs.smartcacheslots;
 
-        //if RNN model AND shifting and fastforward is on, enable smartcache
+        //if RNN or Hybrid model AND shifting and fastforward is on, enable smartcache
+        //Hybrid models (e.g. Granite 4) have both attention and recurrent layers.
+        //Context shifting uses llama_memory_seq_rm/seq_add with partial ranges, which
+        //is not supported by recurrent memory (it cannot partially erase state).
+        //We disable context shifting and enable smartcache instead to handle context management.
         if((llama_model_is_recurrent(llamamodel) || llama_model_is_hybrid(llamamodel)) && kcpp_data->use_fastforward && kcpp_data->use_contextshift)
         {
-            printf("RNN or Hyrbid model with FF and shifting flags enabled - SmartCache will be enabled with extra slots. Disable CtxShift if you do not want this.\n",savestate_limit);
+            if(llama_model_is_hybrid(llamamodel))
+            {
+                printf("Hybrid model detected (has both attention and recurrent/SSM layers).\n");
+                printf("Context shifting is not compatible with recurrent state layers and will be disabled.\n");
+            }
+            else
+            {
+                printf("Recurrent model detected.\n");
+            }
+            printf("SmartCache will be enabled with extra slots for state management. Disable CtxShift if you do not want this.\n");
+            kcpp_data->use_contextshift = false;
             kcpp_data->smartcache = true;
             savestate_limit += 3;
         }
@@ -4296,11 +4351,17 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
             }
             else
             {
-                llama_memory_seq_rm(llama_get_memory(llama_ctx_v4), 0, n_past, -1);
+                bool rm_ok = safe_memory_seq_rm(llama_ctx_v4, 0, n_past, -1);
+                if(!rm_ok)
+                {
+                    //partial removal failed and full clear was done (hybrid/recurrent model)
+                    //reset n_past since the entire memory was cleared
+                    n_past = 0;
+                }
             }
             if(draft_ctx)
             {
-                llama_memory_seq_rm(llama_get_memory(draft_ctx), 0, n_past, -1);
+                safe_memory_seq_rm(draft_ctx, 0, n_past, -1);
             }
         }
     }
@@ -4983,9 +5044,9 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
             //if we have somehow skipped ahead (e.g drafting), ensure that all tokens after npast are purged
             if (file_format == FileFormat::GGUF_GENERIC && draft_used)
             {
-                llama_memory_seq_rm(llama_get_memory(llama_ctx_v4), 0, n_past, -1);
+                safe_memory_seq_rm(llama_ctx_v4, 0, n_past, -1);
                 if (draft_ctx) {
-                    llama_memory_seq_rm(llama_get_memory(draft_ctx), 0, n_past, -1);
+                    safe_memory_seq_rm(draft_ctx, 0, n_past, -1);
                 }
             }
 


### PR DESCRIPTION
## Summary

- Add `safe_memory_seq_rm` wrapper that detects when partial KV cache removal fails on hybrid/recurrent models and falls back to a full memory clear
- Disable context shifting at load time for hybrid models (recurrent state cannot be partially erased)
- Add defensive guard in `DoContextShifting` to reject hybrid/recurrent models
- Handle `seq_rm` failure in the non-recurrent branch by resetting `n_past`

## Background

Granite 4 Hybrid models (e.g. `granite-4.0-h-tiny` 7B-A1B) have both attention layers (4) and Mamba-2 SSM layers (36). The SSM layers use recurrent state that is **not** a KV cache — it cannot be partially erased.

KoboldCpp's cache management calls `llama_memory_seq_rm` with partial position ranges for context shifting, rewind, and other operations. For pure transformer models this works fine, but for hybrid models:

- `llama_memory_seq_rm(mem, 0, n_past, -1)` delegates to both `mem_attn` (succeeds) and `mem_recr` (returns `false` for partial ranges)
- KoboldCpp was **ignoring the return value**, leading to inconsistent state tracking
- This caused the KV cache errors reported in #1781

## Changes (all in `gpttype_adapter.cpp`)

1. **`safe_memory_seq_rm` wrapper** (line ~524): All 8 call sites now go through this wrapper. If partial removal fails on a hybrid model, it performs a full `llama_memory_clear` and logs the fallback.

2. **Load-time guard** (line ~2637): When a hybrid model is loaded with context shifting enabled, context shifting is now explicitly disabled and SmartCache is enabled instead.

3. **`DoContextShifting` guard** (line ~2004): Returns `false` immediately if the model is recurrent or hybrid.

4. **`n_past` reset** (line ~4354): When `safe_memory_seq_rm` performs a full clear, `n_past` is reset to 0 to keep internal tracking consistent.

## Test plan

- [ ] Load Granite 4 Tiny (7B-A1B) GGUF in KoboldCpp — should no longer produce KV cache errors
- [ ] Verify context shifting is automatically disabled for hybrid models
- [ ] Verify SmartCache activates correctly as replacement
- [ ] Test that pure transformer models (e.g. Llama 3) are unaffected by the changes
- [ ] Test multi-turn conversations with Granite 4 to confirm state management works

Fixes #1781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)