### PR TITLE
Fix music generation token stopping

### DIFF
--- a/otherarch/acestep/ace-qwen3.cpp
+++ b/otherarch/acestep/ace-qwen3.cpp
@@ -1000,6 +1000,12 @@ static std::vector<std::string> generate_phase1_batch(
                     seqs[i].fsm.update(tok);
                 if (tok == TOKEN_THINK_END && !seqs[i].codes_phase) {
                     seqs[i].codes_phase = true;
+                    // In lyrics mode (Phase 1), immediately force IM_END to stop generation
+                    // This prevents the quantized model from continuing indefinitely
+                    if (lyrics_mode && !stop_at_reasoning) {
+                        forced_tokens.clear();
+                        forced_tokens.push_back(TOKEN_IM_END);
+                    }
                     if (stop_at_reasoning) {
                         seqs[i].gen_tokens.push_back(tok);
                         seqs[i].done = true;

--- a/otherarch/acestep/ace-qwen3.cpp
+++ b/otherarch/acestep/ace-qwen3.cpp
@@ -1001,7 +1001,7 @@ static std::vector<std::string> generate_phase1_batch(
                 if (tok == TOKEN_THINK_END && !seqs[i].codes_phase) {
                     seqs[i].codes_phase = true;
                     // In lyrics mode (Phase 1), immediately force IM_END to stop generation
-                    // This prevents the quantized model from continuing indefinitely
+                    // This prevents models from continuing indefinitely
                     if (lyrics_mode && !stop_at_reasoning) {
                         forced_tokens.clear();
                         forced_tokens.push_back(TOKEN_IM_END);

--- a/otherarch/acestep/ace-qwen3.cpp
+++ b/otherarch/acestep/ace-qwen3.cpp
@@ -1000,12 +1000,6 @@ static std::vector<std::string> generate_phase1_batch(
                     seqs[i].fsm.update(tok);
                 if (tok == TOKEN_THINK_END && !seqs[i].codes_phase) {
                     seqs[i].codes_phase = true;
-                    // In lyrics mode (Phase 1), immediately force IM_END to stop generation
-                    // This prevents models from continuing indefinitely
-                    if (lyrics_mode && !stop_at_reasoning) {
-                        forced_tokens.clear();
-                        forced_tokens.push_back(TOKEN_IM_END);
-                    }
                     if (stop_at_reasoning) {
                         seqs[i].gen_tokens.push_back(tok);
                         seqs[i].done = true;
@@ -1013,6 +1007,14 @@ static std::vector<std::string> generate_phase1_batch(
                         continue;
                     }
                 }
+
+                // Safety check: if we've reached the token limit, force TOKEN_IM_END
+                // to prevent KV cache exhaustion (FATAL: kv_len > max_seq)
+                if ((int)seqs[i].gen_tokens.size() >= max_new_tokens - 1 && !seqs[i].done) {
+                    forced_tokens.clear();
+                    forced_tokens.push_back(TOKEN_IM_END);
+                }
+
                 seqs[i].gen_tokens.push_back(tok);
             }
             seqs[i].last_token = tok;


### PR DESCRIPTION
## Problem
I was trying to get the music UI working on MacOS. bf16 inference is not hardware accelerated on metal, so I switched for quantised models.

The 'Plan' button would not work for me, as Music Phase 1 planning generation was always continuing generating to the kv cache limit.

## Root Cause
After the FSM guides the model through metadata fields (bpm, caption, duration, keyscale, language, timesignature) and forces `TOKEN_THINK_END`, it transitions to CODES state and disables itself. The model should then naturally generate `TOKEN_IM_END` to stop, but in some cases (especially with quantized models) this doesn't happen efficiently, causing the generation to continue until the KV cache is exhausted.

## Solution
Add a safety check that forces `TOKEN_IM_END` when the generation reaches the token limit. This prevents KV cache exhaustion while still allowing the model to generate normally (including any lyrics after the thinking block).

## Changes
- Modified `otherarch/acestep/ace-qwen3.cpp` to add a safety check before adding each token
- Forces `TOKEN_IM_END` when `gen_tokens.size() >= max_new_tokens - 1`

## Impact
- Prevents KV cache exhaustion errors
- Makes music generation more robust across all model types

Co-Authored-By: GLM-5