### PR TITLE
Fix ~280s startup delay on WSL2: add socket timeout to is_port_in_use()

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2877,6 +2877,7 @@ def websearch(query):
 def is_port_in_use(portNum):
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(1)
             return s.connect_ex(('localhost', portNum)) == 0
     except Exception:
         return True


### PR DESCRIPTION
## Summary

`is_port_in_use()` calls `socket.connect_ex(('localhost', port))` without a timeout. On WSL2 with `networkingMode=mirrored`, connections to non-listening ports get black-holed through the Windows host networking stack — no RST or ECONNREFUSED is returned. TCP SYN retransmits with exponential backoff (`1+2+4+8+16+32+64 ≈ 127s` per port).

Router Mode scans ports 15001–15010 on startup, causing a **~280 second stall** before the model even begins loading.

## Fix

One line: add `s.settimeout(1)` before `connect_ex()`. This makes the port check fail fast (1 second) instead of waiting for the full TCP timeout.

## Results

| | Before | After |
|---|---|---|
| Startup to API ready | ~303s | **~23s** |
| Generation | works | works |

## Environment

- WSL2 Ubuntu 24.04, `networkingMode=mirrored` in `.wslconfig`
- KoboldCpp v1.110 with Router Mode enabled
- RTX 3090 Ti, Qwen3.5-27B Q4_K_M
- Windows 11 24H2 Build 26100

## Root Cause Detail

WSL2's mirrored networking mode shares the host's network stack. When `connect_ex()` targets `localhost` on a port that isn't listening, the SYN packet enters the Windows host stack and gets silently dropped (no RST returned), unlike native Linux which returns `ECONNREFUSED` immediately. Without a socket timeout, Python's `connect_ex()` waits for the OS-level TCP connect timeout, which is ~127 seconds with standard retransmit backoff.

This affects any WSL2 user with `networkingMode=mirrored` in their `.wslconfig` who uses Router Mode.