### PR TITLE
Henk's Gemma4 31B Magic

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -3847,6 +3847,26 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
         }
     }
 
+    // Round two, gemma4 boogalo
+    // If it breaks your stuff you can blame me again (Or thank me because you can actually use gemma 31B stable now). - Henk
+    // For the record, the GLM4 one didn't break anyone and everyone forgot GLM4 needed this :D
+    if (file_format == FileFormat::GGUF_GENERIC && (file_format_meta.model_architecture == llm_arch::LLM_ARCH_GEMMA4)) {
+        std::string temp = gpttype_get_chat_template();
+        if (temp.find("<|channel>thought") != std::string::npos) {
+            const std::string channel_open  = "<|channel>";
+            const std::string channel_close = "<channel|>";
+            const std::string channel_prefix = channel_open + channel_close;
+
+            const bool has_open  = kcpp_data->prompt.find(channel_open)  != std::string::npos;
+            const bool has_close = kcpp_data->prompt.find(channel_close) != std::string::npos;
+
+            // If neither opening nor closing tag is present anywhere, prepend both
+            if (!has_open && !has_close) {
+                kcpp_data->prompt = channel_prefix + kcpp_data->prompt;
+            }
+        }
+    }
+
     bool stream_sse = inputs.stream_sse;
     bool allow_regular_prints = (!is_quiet && debugmode!=-1);
 


### PR DESCRIPTION
Like I did before with GLM I went to toy around with the model to see if I could come up with a workaround on how to remove some of the restrictions.

This one is a hit for 31B and I applied it underneath the GLM4 fix where you blame me for fixing it for everyone :P
Lets do this again and automatically inject the stuff its expecting if the frontend didn't.

So far:
- People who were using concedobot can now use that properly again.
- Tavern worked with the KoboldAI preset without issues
- I tried the real Gemma4 template and that still works
- Jinja with thinking enabled still works
- Jinja without thinking enabled still works
- Not using jinja at all still works
- Adventure mode worked for someone

And even if you go off the rails and use alpaca, it still works:
<img width="1186" height="264" alt="image" src="https://github.com/user-attachments/assets/472e1522-5c9a-4107-a610-b8d3014e62b5" />
