### PR TITLE
fix high CPU usage when providing IPv6-only host command line parameter

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -6934,13 +6934,33 @@ def RunServerMultiThreaded(addr, port, server_handler):
             self.daemon = True
             self.start()
 
+        # Workaround for a !1809
+        def check_ip_version(self, addr):
+            v4 = False
+            v6 = False
+
+            try:
+                socket.getaddrinfo(addr, None, socket.AF_INET)
+                v4 = True
+            except:
+                pass
+
+            try:
+                socket.getaddrinfo(addr, None, socket.AF_INET6)
+                v6 = True
+            except:
+                pass
+
+            return v4, v6
+
         def run(self):
             global exitcounter
             handler = server_handler(addr, port)
+            enable_v4, enable_v6 = self.check_ip_version(addr)
             with http.server.HTTPServer((addr, port), handler, False) as self.httpd:
                 try:
                     if ipv6_sock:
-                        self.httpd.socket = ipv4_sock if self.i < 16 else ipv6_sock
+                        self.httpd.socket = ipv4_sock if (self.i < 16 and enable_v4) else ipv6_sock
                     else:
                         self.httpd.socket = ipv4_sock
 


### PR DESCRIPTION
Trying out koboldcpp I encountered the same problem as in #1809 

As far as I can tell, passing the ipv4 socket, created by default as a fallback to the HTTP server function will cause an infinite loop trying to bind inside the web server. The existing code divides server threads between IPv4 and IPv6 regardless.

These changes check if the host provided (IP or hostname) even has an IPv6 address before passing the socket.