### PR TITLE
feat(router): make router-mode reverse-proxy timeout configurable via --routermodetimeout

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4417,7 +4417,7 @@ class KcppProxyHandler(http.server.BaseHTTPRequestHandler):
                         }
                         if args.adminpassword:
                             reqheaders["Authorization"] = f"Bearer {args.adminpassword}"
-                        conn = http.client.HTTPConnection('localhost', upstream_port, timeout=600)
+                        conn = http.client.HTTPConnection('localhost', upstream_port, timeout=args.routermodetimeout)
                         conn.request("POST", "/api/admin/reload_config", body=reqbody, headers=reqheaders)
                         resp = conn.getresponse()
                         time.sleep(3)
@@ -4463,7 +4463,7 @@ class KcppProxyHandler(http.server.BaseHTTPRequestHandler):
                     }
                     if args.adminpassword:
                         reqheaders["Authorization"] = f"Bearer {args.adminpassword}"
-                    conn = http.client.HTTPConnection('localhost', upstream_port, timeout=600)
+                    conn = http.client.HTTPConnection('localhost', upstream_port, timeout=args.routermodetimeout)
                     conn.request("POST", "/api/admin/reload_config", body=reqbody, headers=reqheaders)
                     resp = conn.getresponse()
                     time.sleep(3)
@@ -4474,7 +4474,7 @@ class KcppProxyHandler(http.server.BaseHTTPRequestHandler):
                     time.sleep(0.1)
 
         try:  # connect upstream
-            conn = http.client.HTTPConnection('localhost', upstream_port, timeout=600)
+            conn = http.client.HTTPConnection('localhost', upstream_port, timeout=args.routermodetimeout)
             conn.request( self.command, self.path, body=body, headers=headers)
             resp = conn.getresponse()
         except OSError as e:
@@ -11447,6 +11447,7 @@ if __name__ == '__main__':
     admingroup.add_argument("--admindir", metavar=('[directory]'), help="Specify a directory to look for .kcpps configs in, which can be used to swap models.", default="")
     admingroup.add_argument("--adminunloadtimeout", help="Set an idle timeout in seconds after which KoboldCpp will automatically unload the current model.", type=int, default=0)
     admingroup.add_argument("--routermode", help="Router mode uses a reverse proxy router, allowing you to easily hotswap models and configs within a single request. Requires admin mode.", action='store_true')
+    admingroup.add_argument("--routermodetimeout", metavar=('[seconds]'), help="Timeout in seconds for the router-mode reverse proxy when forwarding requests to the loaded backend (also applies to admin reload calls). Increase this if long generations are being cut off at the proxy. Defaults to 600.", type=int, default=600)
     admingroup.add_argument("--autoswapmode", help="Autoswap mode builds on router mode to allow switching of model types within the same config automatically. Requires admin mode and router mode. All models desired must be defined within the same config.", action='store_true')
     admingroup.add_argument("--baseconfig", help="Specify a base .kcpps config to apply, if no custom base config is selected during a model swap", default="")
 


### PR DESCRIPTION
## Summary

Adds a `--routermodetimeout` CLI flag (default 600 seconds) that controls the upstream `HTTPConnection` timeout used by the router-mode reverse proxy in `koboldcpp.py`. Long generations through `--routermode` were previously cut off after 600s because the timeout was hardcoded.

Reported in [#2168](https://github.com/LostRuins/koboldcpp/issues/2168) — a long AIME-problem generation timed out at exactly 600s under `--admin --routermode`, returning malformed (HTML) JSON to the client. Removing `--routermode` made it work, confirming the proxy timeout was the cause.

## Why

The handler that proxies requests to the loaded backend uses three `http.client.HTTPConnection(...)` calls with a literal `timeout=600`:

- `koboldcpp.py:4477` — main upstream proxy forward (this is the one that hits user generations).
- `koboldcpp.py:4420` — admin reload during a model swap.
- `koboldcpp.py:4466` — admin reload after `swapModeChanged` in autoswap mode.

The user has no way to raise the limit, even though `--adminunloadtimeout` already configures the *unrelated* idle-unload behavior. A long generation, large-context evaluation, or slow model swap (loading a big GGUF can also exceed 10 minutes) hits the proxy's hardcoded ceiling and returns a 502/HTML page instead of streaming through.

## Change

- **CLI**: new `--routermodetimeout [seconds]` under the existing admin argument group, `type=int, default=600`. Description explains it covers both the proxy forward and the admin reload calls.
- **Handler**: the three `timeout=600` references become `timeout=args.routermodetimeout`. No other behavior changes; the default keeps existing setups identical.

The argument lives next to `--routermode` so it's discoverable when users read `--help`.

## Test plan

- [x] `python -m py_compile koboldcpp.py` — passes.
- [x] AST parse — passes.
- [ ] Manual: launch with `--admin --routermode --routermodetimeout 3600`; confirm `args.routermodetimeout == 3600` and a >10-minute generation is no longer truncated. *(Cannot run locally — would appreciate a spot-check by anyone with the routermode setup.)*
- [ ] Default unchanged: launching without the new flag should keep the 600s behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)