### PR TITLE
sd: build each source file separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,23 +681,27 @@ llama-impl.o: src/llama-impl.cpp src/llama-impl.h
 budget.o: common/reasoning-budget.cpp common/reasoning-budget.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-SDCPP_COMMON_BASENAMES := stable-diffusion.h stable-diffusion.cpp sample-cache.h sample-cache.cpp util.cpp upscaler.h upscaler.cpp model.cpp name_conversion.cpp model_io/gguf_io.cpp model_io/gguf_io.h model_io/gguf_reader_ext.h model_io/pickle_io.cpp model_io/safetensors_io.cpp model_io/safetensors_io.h model_io/tensor_storage.h model_io/torch_legacy_io.cpp model_io/torch_zip_io.cpp tokenizers/bpe_tokenizer.cpp tokenizers/bpe_tokenizer.h tokenizers/clip_tokenizer.cpp tokenizers/clip_tokenizer.h tokenizers/mistral_tokenizer.cpp tokenizers/mistral_tokenizer.h tokenizers/qwen2_tokenizer.cpp tokenizers/qwen2_tokenizer.h tokenizers/t5_unigram_tokenizer.cpp tokenizers/t5_unigram_tokenizer.h tokenizers/tokenizer.cpp tokenizers/tokenizer.h tokenizers/tokenize_util.cpp tokenizers/tokenize_util.h thirdparty/zip.c
-SDCPP_COMMON_SOURCES := $(foreach f,$(SDCPP_COMMON_BASENAMES),otherarch/sdcpp/$(f))
-SDCPP_FLAGS := -I./vendor/nlohmann
+SDCPP_COMMON_BASENAMES := anima.hpp auto_encoder_kl.hpp avi_writer.h cache_dit.hpp clip.hpp common_block.hpp  common_dit.hpp  condition_cache_utils.hpp conditioner.hpp control.hpp convert.cpp denoiser.hpp diffusion_model.hpp easycache.hpp ernie_image.hpp esrgan.hpp flux.hpp ggml_extend_backend.hpp ggml_extend.hpp image_metadata.cpp image_metadata.h kcpp_sd_extensions.h latent-preview.h llm.hpp lora.hpp ltxv.hpp mmdit.hpp model.cpp model.h model_io/binary_io.h model_io/gguf_io.cpp model_io/gguf_io.h model_io/gguf_reader_ext.h model_io/pickle_io.cpp model_io/pickle_io.h model_io/safetensors_io.cpp model_io/safetensors_io.h model_io/tensor_storage.h model_io/torch_legacy_io.cpp model_io/torch_legacy_io.h model_io/torch_zip_io.cpp model_io/torch_zip_io.h msf_gif.h name_conversion.cpp name_conversion.h ordered_map.hpp pmid.hpp preprocessing.hpp qwen_image.hpp rng.hpp rng_mt19937.hpp rng_philox.hpp rope.hpp sample-cache.cpp sample-cache.h spectrum.hpp stable-diffusion.cpp stable-diffusion.h t5.hpp tae.hpp tensor_ggml.hpp tensor.hpp thirdparty/darts.h thirdparty/miniz.h thirdparty/stb_image_resize.h thirdparty/stb_image_write.h thirdparty/zip.c thirdparty/zip.h tokenizers/bpe_tokenizer.cpp tokenizers/bpe_tokenizer.h tokenizers/clip_tokenizer.cpp tokenizers/clip_tokenizer.h tokenizers/mistral_tokenizer.cpp tokenizers/mistral_tokenizer.h tokenizers/qwen2_tokenizer.cpp tokenizers/qwen2_tokenizer.h tokenizers/t5_unigram_tokenizer.cpp tokenizers/t5_unigram_tokenizer.h tokenizers/tokenizer.cpp tokenizers/tokenizer.h tokenizers/tokenize_util.cpp tokenizers/tokenize_util.h  tokenizers/vocab/vocab.h ucache.hpp unet.hpp upscaler.cpp upscaler.h util.cpp util.h vae.hpp version.cpp wan.hpp z_image.hpp
 
-SDCPP_MAIN_BASENAMES := main.cpp image_metadata.cpp convert.cpp common/log.cpp common/media_io.cpp common/common.cpp version.cpp tokenizers/vocab/vocab.cpp
+SDCPP_MAIN_BASENAMES := common/common.cpp common/common.h common/log.cpp common/log.h common/media_io.cpp common/media_io.cpp common/media_io.h common/resource_owners.hpp convert.cpp image_metadata.cpp main.cpp version.cpp tokenizers/vocab/clip_t5.hpp tokenizers/vocab/mistral.hpp tokenizers/vocab/qwen.hpp tokenizers/vocab/umt5.hpp tokenizers/vocab/vocab.cpp
 
-HEADERS_SDCOMMON := $(filter %.h,$(SDCPP_COMMON_SOURCES)) $(filter %.hpp, $(SDCPP_COMMON_SOURCES))
-OBJS_SDCOMMON := $(patsubst %.cpp,%.o,$(filter %.cpp,$(SDCPP_COMMON_SOURCES))) otherarch/sdcpp/thirdparty/zip.o
+SOURCES_SDCOMMON := $(foreach f,$(SDCPP_COMMON_BASENAMES),otherarch/sdcpp/$(f))
+HEADERS_SDCOMMON := $(filter %.h,$(SOURCES_SDCOMMON)) $(filter %.hpp, $(SOURCES_SDCOMMON))
+OBJS_SDCOMMON := $(patsubst %.cpp,%.o,$(filter %.cpp,$(SOURCES_SDCOMMON))) otherarch/sdcpp/thirdparty/zip.o
 
-OBJS_SDMAIN := $(patsubst %.cpp,%.o,$(filter %.cpp,$(foreach f,$(SDCPP_MAIN_BASENAMES),otherarch/sdcpp/$(f))))
+SOURCES_SDMAIN := $(foreach f,$(SDCPP_MAIN_BASENAMES),otherarch/sdcpp/$(f))
+HEADERS_SDMAIN := $(filter %.h,$(SOURCES_SDMAIN)) $(filter %.hpp, $(SOURCES_SDMAIN))
+OBJS_SDMAIN := $(patsubst %.cpp,%.o,$(filter %.cpp,$(SOURCES_SDMAIN)))
 
 otherarch/sdcpp/%.o: $(HEADERS_SDCOMMON)
+
+$(OBJS_SDMAIN): $(HEADERS_SDMAIN)
+
+SDCPP_FLAGS := -I./vendor/nlohmann
 
 otherarch/sdcpp/%.o: otherarch/sdcpp/%.cpp
 	$(CXX) $(CXXFLAGS) $(SDCPP_FLAGS) -c $< -o $@
 
-# Compile zip.c (C file)
 otherarch/sdcpp/thirdparty/zip.o: otherarch/sdcpp/thirdparty/zip.c
 	$(CC) $(CFLAGS) $(SDCPP_FLAGS) -c $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -681,13 +681,27 @@ llama-impl.o: src/llama-impl.cpp src/llama-impl.h
 budget.o: common/reasoning-budget.cpp common/reasoning-budget.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-SDCPP_COMMON_BASENAMES := stable-diffusion.h stable-diffusion.cpp sample-cache.h sample-cache.cpp util.cpp upscaler.h upscaler.cpp model.cpp name_conversion.cpp model_io/gguf_io.cpp model_io/gguf_io.h model_io/gguf_reader_ext.h model_io/pickle_io.cpp model_io/safetensors_io.cpp model_io/safetensors_io.h model_io/tensor_storage.h model_io/torch_legacy_io.cpp model_io/torch_zip_io.cpp tokenizers/bpe_tokenizer.cpp tokenizers/bpe_tokenizer.h tokenizers/clip_tokenizer.cpp tokenizers/clip_tokenizer.h tokenizers/mistral_tokenizer.cpp tokenizers/mistral_tokenizer.h tokenizers/qwen2_tokenizer.cpp tokenizers/qwen2_tokenizer.h tokenizers/t5_unigram_tokenizer.cpp tokenizers/t5_unigram_tokenizer.h tokenizers/tokenizer.cpp tokenizers/tokenizer.h tokenizers/tokenize_util.cpp tokenizers/tokenize_util.h thirdparty/zip.c
+SDCPP_COMMON_BASENAMES := stable-diffusion.h sample-cache.h sample-cache.cpp util.cpp upscaler.h upscaler.cpp model.cpp name_conversion.cpp model_io/gguf_io.cpp model_io/gguf_io.h model_io/gguf_reader_ext.h model_io/pickle_io.cpp model_io/safetensors_io.cpp model_io/safetensors_io.h model_io/tensor_storage.h model_io/torch_legacy_io.cpp model_io/torch_zip_io.cpp tokenizers/bpe_tokenizer.cpp tokenizers/bpe_tokenizer.h tokenizers/clip_tokenizer.cpp tokenizers/clip_tokenizer.h tokenizers/mistral_tokenizer.cpp tokenizers/mistral_tokenizer.h tokenizers/qwen2_tokenizer.cpp tokenizers/qwen2_tokenizer.h tokenizers/t5_unigram_tokenizer.cpp tokenizers/t5_unigram_tokenizer.h tokenizers/tokenizer.cpp tokenizers/tokenizer.h tokenizers/tokenize_util.cpp tokenizers/tokenize_util.h thirdparty/zip.c
 SDCPP_COMMON_SOURCES := $(foreach f,$(SDCPP_COMMON_BASENAMES),otherarch/sdcpp/$(f))
 SDCPP_FLAGS := -I./vendor/nlohmann
 
-# sd.cpp objects
-sdcpp_default.o: otherarch/sdcpp/sdtype_adapter.cpp $(SDCPP_COMMON_SOURCES)
+SDCPP_MAIN_BASENAMES := main.cpp stable-diffusion.cpp image_metadata.cpp convert.cpp common/log.cpp common/media_io.cpp common/common.cpp version.cpp tokenizers/vocab/vocab.cpp
+
+HEADERS_SDCOMMON := $(filter %.h,$(SDCPP_COMMON_SOURCES)) $(filter %.hpp, $(SDCPP_COMMON_SOURCES))
+OBJS_SDCOMMON := $(patsubst %.cpp,%.o,$(filter %.cpp,$(SDCPP_COMMON_SOURCES))) otherarch/sdcpp/thirdparty/zip.o
+
+OBJS_SDMAIN := $(patsubst %.cpp,%.o,$(filter %.cpp,$(foreach f,$(SDCPP_MAIN_BASENAMES),otherarch/sdcpp/$(f))))
+
+otherarch/sdcpp/%.o: $(HEADERS_SDCOMMON)
+
+otherarch/sdcpp/%.o: otherarch/sdcpp/%.cpp
 	$(CXX) $(CXXFLAGS) $(SDCPP_FLAGS) -c $< -o $@
+
+# Compile zip.c (C file)
+otherarch/sdcpp/thirdparty/zip.o: otherarch/sdcpp/thirdparty/zip.c
+	$(CC) $(CFLAGS) $(SDCPP_FLAGS) -c $< -o $@
+
+OBJS_SDTYPE := otherarch/sdcpp/sdtype_adapter.o $(OBJS_SDCOMMON)
 
 
 #whisper objects
@@ -726,6 +740,7 @@ clean:
 	rm -vrf ggml/src/ggml-cuda/*.o
 	rm -vrf ggml/src/ggml-cuda/template-instances/*.o
 	rm -vrf llguidance
+	rm -vf otherarch/sdcpp/*.o otherarch/sdcpp/*/*.o otherarch/sdcpp/*/*/*.o
 
 # useful tools
 main: tools/completion/completion.cpp common/arg.cpp common/speculative.cpp common/ngram-cache.cpp common/ngram-map.cpp common/ngram-mod.cpp common/chat.cpp common/preset.cpp common/download.cpp build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o console.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
@@ -734,7 +749,7 @@ mainvk: tools/completion/completion.cpp common/arg.cpp common/speculative.cpp co
 	$(CXX) $(CXXFLAGS) -DGGML_USE_VULKAN -DSD_USE_VULKAN $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 fitparams: tools/fit-params/fit-params.cpp common/arg.cpp common/speculative.cpp common/ngram-cache.cpp common/ngram-map.cpp common/ngram-mod.cpp common/chat.cpp common/preset.cpp common/download.cpp build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o console.o llavaclip_vulkan.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
 	$(CXX) $(CXXFLAGS) -DGGML_USE_VULKAN -DSD_USE_VULKAN $(filter-out %.h,$^) -o $@ $(LDFLAGS)
-sdmain: $(SDCPP_COMMON_SOURCES) otherarch/sdcpp/main.cpp otherarch/sdcpp/image_metadata.cpp otherarch/sdcpp/convert.cpp otherarch/sdcpp/common/log.cpp otherarch/sdcpp/common/media_io.cpp otherarch/sdcpp/common/common.cpp otherarch/sdcpp/version.cpp otherarch/sdcpp/tokenizers/vocab/vocab.cpp build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o console.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
+sdmain: $(OBJS_SDCOMMON) $(OBJS_SDMAIN) build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o console.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(SDCPP_FLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 whispermain: otherarch/whispercpp/main.cpp otherarch/whispercpp/whisper.cpp build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o console.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
@@ -851,11 +866,11 @@ else
 endif
 
 #generated libraries
-koboldcpp_default: ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3.o ggml_v2.o ggml_v1.o expose.o gpttype_adapter.o sdcpp_default.o whispercpp_default.o tts_default.o music_default.o embeddings_default.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
+koboldcpp_default: ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3.o ggml_v2.o ggml_v1.o expose.o gpttype_adapter.o $(OBJS_SDTYPE) whispercpp_default.o tts_default.o music_default.o embeddings_default.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(DEFAULT_BUILD)
 
 ifdef FAILSAFE_BUILD
-koboldcpp_failsafe: ggml_v4_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml-binops.o ggml-unops.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o expose.o gpttype_adapter_failsafe.o sdcpp_default.o whispercpp_default.o tts_default.o music_default.o embeddings_default.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FAILSAFE) $(OBJS)
+koboldcpp_failsafe: ggml_v4_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml-binops.o ggml-unops.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o expose.o gpttype_adapter_failsafe.o $(OBJS_SDTYPE) whispercpp_default.o tts_default.o music_default.o embeddings_default.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FAILSAFE) $(OBJS)
 	$(FAILSAFE_BUILD)
 else
 koboldcpp_failsafe:
@@ -863,7 +878,7 @@ koboldcpp_failsafe:
 endif
 
 ifdef NOAVX2_BUILD
-koboldcpp_noavx2: ggml_v4_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml-binops.o ggml-unops.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o expose.o gpttype_adapter_failsafe.o sdcpp_default.o whispercpp_default.o tts_default.o music_default.o embeddings_default.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_SIMPLE) $(OBJS)
+koboldcpp_noavx2: ggml_v4_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml-binops.o ggml-unops.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o expose.o gpttype_adapter_failsafe.o $(OBJS_SDTYPE) whispercpp_default.o tts_default.o music_default.o embeddings_default.o llavaclip_default.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_SIMPLE) $(OBJS)
 	$(NOAVX2_BUILD)
 else
 koboldcpp_noavx2:
@@ -871,7 +886,7 @@ koboldcpp_noavx2:
 endif
 
 ifdef CUBLAS_BUILD
-koboldcpp_cublas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o expose.o gpttype_adapter_cublas.o sdcpp_default.o whispercpp_cublas.o tts_default.o music_default.o embeddings_default.o llavaclip_cublas.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_cublas.o ggml-repack.o $(CUBLAS_OBJS) $(OBJS_FULL) $(OBJS)
+koboldcpp_cublas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o expose.o gpttype_adapter_cublas.o $(OBJS_SDTYPE) whispercpp_cublas.o tts_default.o music_default.o embeddings_default.o llavaclip_cublas.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_cublas.o ggml-repack.o $(CUBLAS_OBJS) $(OBJS_FULL) $(OBJS)
 	$(CUBLAS_BUILD)
 else
 koboldcpp_cublas:
@@ -879,7 +894,7 @@ koboldcpp_cublas:
 endif
 
 ifdef HIPBLAS_BUILD
-koboldcpp_hipblas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o expose.o gpttype_adapter_cublas.o sdcpp_default.o whispercpp_cublas.o tts_default.o music_default.o embeddings_default.o llavaclip_cublas.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_cublas.o ggml-repack.o $(HIP_OBJS) $(OBJS_FULL) $(OBJS)
+koboldcpp_hipblas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o expose.o gpttype_adapter_cublas.o $(OBJS_SDTYPE) whispercpp_cublas.o tts_default.o music_default.o embeddings_default.o llavaclip_cublas.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_cublas.o ggml-repack.o $(HIP_OBJS) $(OBJS_FULL) $(OBJS)
 	$(HIPBLAS_BUILD)
 else
 koboldcpp_hipblas:
@@ -887,12 +902,12 @@ koboldcpp_hipblas:
 endif
 
 ifdef VULKAN_BUILD
-koboldcpp_vulkan: ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3.o ggml_v2.o ggml_v1.o expose.o gpttype_adapter_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o sdcpp_default.o whispercpp_vulkan.o tts_default.o music_default.o embeddings_default.o llavaclip_vulkan.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-repack.o $(OBJS_FULL) $(OBJS)
+koboldcpp_vulkan: ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o ggml_v3.o ggml_v2.o ggml_v1.o expose.o gpttype_adapter_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o $(OBJS_SDTYPE) whispercpp_vulkan.o tts_default.o music_default.o embeddings_default.o llavaclip_vulkan.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(VULKAN_BUILD)
 ifdef NOAVX2_BUILD
-koboldcpp_vulkan_noavx2: ggml_v4_vulkan_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml-binops.o ggml-unops.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o expose.o gpttype_adapter_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o sdcpp_default.o whispercpp_vulkan.o tts_default.o music_default.o embeddings_default.o llavaclip_vulkan.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-repack.o $(OBJS_SIMPLE) $(OBJS)
+koboldcpp_vulkan_noavx2: ggml_v4_vulkan_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml-binops.o ggml-unops.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o expose.o gpttype_adapter_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o $(OBJS_SDTYPE) whispercpp_vulkan.o tts_default.o music_default.o embeddings_default.o llavaclip_vulkan.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-repack.o $(OBJS_SIMPLE) $(OBJS)
 	$(VULKAN_BUILD)
-koboldcpp_vulkan_failsafe: ggml_v4_vulkan_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml-binops.o ggml-unops.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o expose.o gpttype_adapter_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o sdcpp_default.o whispercpp_vulkan.o tts_default.o music_default.o embeddings_default.o llavaclip_vulkan.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-repack.o $(OBJS_SIMPLER) $(OBJS)
+koboldcpp_vulkan_failsafe: ggml_v4_vulkan_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml-binops.o ggml-unops.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o expose.o gpttype_adapter_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o $(OBJS_SDTYPE) whispercpp_vulkan.o tts_default.o music_default.o embeddings_default.o llavaclip_vulkan.o llava.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-repack.o $(OBJS_SIMPLER) $(OBJS)
 	$(VULKAN_BUILD)
 else
 koboldcpp_vulkan_noavx2:

--- a/Makefile
+++ b/Makefile
@@ -681,11 +681,11 @@ llama-impl.o: src/llama-impl.cpp src/llama-impl.h
 budget.o: common/reasoning-budget.cpp common/reasoning-budget.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-SDCPP_COMMON_BASENAMES := stable-diffusion.h sample-cache.h sample-cache.cpp util.cpp upscaler.h upscaler.cpp model.cpp name_conversion.cpp model_io/gguf_io.cpp model_io/gguf_io.h model_io/gguf_reader_ext.h model_io/pickle_io.cpp model_io/safetensors_io.cpp model_io/safetensors_io.h model_io/tensor_storage.h model_io/torch_legacy_io.cpp model_io/torch_zip_io.cpp tokenizers/bpe_tokenizer.cpp tokenizers/bpe_tokenizer.h tokenizers/clip_tokenizer.cpp tokenizers/clip_tokenizer.h tokenizers/mistral_tokenizer.cpp tokenizers/mistral_tokenizer.h tokenizers/qwen2_tokenizer.cpp tokenizers/qwen2_tokenizer.h tokenizers/t5_unigram_tokenizer.cpp tokenizers/t5_unigram_tokenizer.h tokenizers/tokenizer.cpp tokenizers/tokenizer.h tokenizers/tokenize_util.cpp tokenizers/tokenize_util.h thirdparty/zip.c
+SDCPP_COMMON_BASENAMES := stable-diffusion.h stable-diffusion.cpp sample-cache.h sample-cache.cpp util.cpp upscaler.h upscaler.cpp model.cpp name_conversion.cpp model_io/gguf_io.cpp model_io/gguf_io.h model_io/gguf_reader_ext.h model_io/pickle_io.cpp model_io/safetensors_io.cpp model_io/safetensors_io.h model_io/tensor_storage.h model_io/torch_legacy_io.cpp model_io/torch_zip_io.cpp tokenizers/bpe_tokenizer.cpp tokenizers/bpe_tokenizer.h tokenizers/clip_tokenizer.cpp tokenizers/clip_tokenizer.h tokenizers/mistral_tokenizer.cpp tokenizers/mistral_tokenizer.h tokenizers/qwen2_tokenizer.cpp tokenizers/qwen2_tokenizer.h tokenizers/t5_unigram_tokenizer.cpp tokenizers/t5_unigram_tokenizer.h tokenizers/tokenizer.cpp tokenizers/tokenizer.h tokenizers/tokenize_util.cpp tokenizers/tokenize_util.h thirdparty/zip.c
 SDCPP_COMMON_SOURCES := $(foreach f,$(SDCPP_COMMON_BASENAMES),otherarch/sdcpp/$(f))
 SDCPP_FLAGS := -I./vendor/nlohmann
 
-SDCPP_MAIN_BASENAMES := main.cpp stable-diffusion.cpp image_metadata.cpp convert.cpp common/log.cpp common/media_io.cpp common/common.cpp version.cpp tokenizers/vocab/vocab.cpp
+SDCPP_MAIN_BASENAMES := main.cpp image_metadata.cpp convert.cpp common/log.cpp common/media_io.cpp common/common.cpp version.cpp tokenizers/vocab/vocab.cpp
 
 HEADERS_SDCOMMON := $(filter %.h,$(SDCPP_COMMON_SOURCES)) $(filter %.hpp, $(SDCPP_COMMON_SOURCES))
 OBJS_SDCOMMON := $(patsubst %.cpp,%.o,$(filter %.cpp,$(SDCPP_COMMON_SOURCES))) otherarch/sdcpp/thirdparty/zip.o

--- a/otherarch/sdcpp/kcpp_sd_extensions.h
+++ b/otherarch/sdcpp/kcpp_sd_extensions.h
@@ -1,0 +1,33 @@
+#ifndef __KCPP_SD_EXTENSIONS_H__
+#define __KCPP_SD_EXTENSIONS_H__
+
+#include "stable-diffusion.h"
+#include <vector>
+
+namespace kcpp_sd {
+
+    struct model_info {
+        bool is_chroma;
+        bool is_flux1;
+        bool is_flux2;
+        bool is_kontext;
+        bool is_qwenimg;
+        bool is_sd1;
+        bool is_sd2;
+        bool is_sdxs;
+        bool is_wan;
+        bool is_zimage;
+        int spatial_multiple;
+    };
+
+    model_info get_model_info(sd_ctx_t* ctx);
+
+    void SetCircularAxesAll(sd_ctx_t* ctx, bool circular_x, bool circular_y);
+
+    void set_lora_cache(sd_ctx_t *ctx, bool enable);
+
+    void apply_loras(sd_ctx_t *ctx, const std::vector<sd_lora_t>& lora_specs);
+
+}
+
+#endif

--- a/otherarch/sdcpp/kcpp_sd_extensions.h
+++ b/otherarch/sdcpp/kcpp_sd_extensions.h
@@ -28,6 +28,12 @@ namespace kcpp_sd {
 
     void apply_loras(sd_ctx_t *ctx, const std::vector<sd_lora_t>& lora_specs);
 
+    void set_sd_quiet(bool quiet);
+
+    void set_sd_log_level(int log);
+
+    void config_main_gpu(int value);
+
 }
 
 #endif

--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -18,44 +18,8 @@
 
 #include "model_adapter.h"
 #include "tokenizers/vocab/vocab.h"
+#include "tokenizers/bpe_tokenizer.h"
 #include "flux.hpp"
-#include "sample-cache.cpp"
-#include "util.cpp"
-#include "name_conversion.cpp"
-#include "upscaler.cpp"
-
-#include "zip.c"
-#include "model_io/binary_io.h"
-namespace pickle {
-#include "model_io/pickle_io.cpp"
-}
-namespace gguf {
-#include "model_io/gguf_io.cpp"
-}
-namespace safetensors {
-#include "model_io/safetensors_io.cpp"
-}
-using namespace pickle;
-namespace torch_legacy {
-#include "model_io/torch_legacy_io.cpp"
-}
-namespace torch_zip {
-#include "model_io/torch_zip_io.cpp"
-}
-using namespace gguf;
-using namespace safetensors;
-using namespace torch_legacy;
-using namespace torch_zip;
-#include "model.cpp"
-
-#include "tokenizers/bpe_tokenizer.cpp"
-#include "tokenizers/clip_tokenizer.cpp"
-#include "tokenizers/mistral_tokenizer.cpp"
-#include "tokenizers/qwen2_tokenizer.cpp"
-#include "tokenizers/t5_unigram_tokenizer.cpp"
-#include "tokenizers/tokenizer.cpp"
-#include "tokenizers/tokenize_util.cpp"
-
 
 // #include "preprocessing.hpp"
 #include "stable-diffusion.h"

--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -15,15 +15,14 @@
 #include <filesystem>
 
 #include "otherarch/utils.h"
-
 #include "model_adapter.h"
-#include "tokenizers/vocab/vocab.h"
-#include "tokenizers/bpe_tokenizer.h"
-#include "flux.hpp"
 
 // #include "preprocessing.hpp"
 #include "stable-diffusion.h"
-#include "stable-diffusion.cpp"
+#include "util.h"
+#include "kcpp_sd_extensions.h"
+
+using namespace kcpp_sd;
 
 //#define STB_IMAGE_IMPLEMENTATION //already defined in llava
 #include "stb_image.h"
@@ -36,9 +35,6 @@
 #include "stb_image_resize.h"
 
 #include "avi_writer.h"
-
-static_assert((int)SD_TYPE_COUNT == (int)GGML_TYPE_COUNT,
-              "inconsistency between SD_TYPE_COUNT and GGML_TYPE_COUNT");
 
 struct LoraMap {
     std::vector<std::pair<std::string, float>> items;
@@ -188,22 +184,6 @@ static struct {
         return outputs(0);
     }
 } sd_generation;
-
-static int get_loaded_sd_version(sd_ctx_t* ctx)
-{
-    return ctx->sd->version;
-}
-
-static bool loaded_model_is_chroma(sd_ctx_t* ctx)
-{
-    if (ctx != nullptr && ctx->sd != nullptr) {
-        auto maybe_flux = std::dynamic_pointer_cast<FluxModel>(ctx->sd->diffusion_model);
-        if (maybe_flux != nullptr) {
-            return maybe_flux->flux.flux_params.is_chroma;
-        }
-    }
-    return false;
-}
 
 static std::string read_str_from_disk(std::string filepath)
 {
@@ -475,18 +455,19 @@ bool sdtype_load_model(const sd_load_model_inputs inputs) {
         return false;
     }
 
+    auto info = get_model_info(sd_ctx);
+
     if (!sd_is_quiet) {
-        if (loaded_model_is_chroma(sd_ctx) && sd_params->diffusion_flash_attn && sd_params->chroma_use_dit_mask)
+        if (info.is_chroma && sd_params->diffusion_flash_attn && sd_params->chroma_use_dit_mask)
         {
             printf("Chroma: flash attention is on, disabling DiT mask (this will lower image quality)\n");
             // disabled before loading
         }
     }
 
-    auto loadedsdver = get_loaded_sd_version(sd_ctx);
-    if (loadedsdver == SDVersion::VERSION_WAN2 || loadedsdver == SDVersion::VERSION_WAN2_2_I2V || loadedsdver == SDVersion::VERSION_WAN2_2_TI2V)
+    if (info.is_wan)
     {
-        printf("\nVer %d, Setting to Video Generation Mode!\n",loadedsdver);
+        printf("\nSetting to Video Generation Mode!\n");
         is_vid_model = true;
     }
 
@@ -495,9 +476,9 @@ bool sdtype_load_model(const sd_load_model_inputs inputs) {
     if(lora_specs.size()>0)
     {
         printf("  applying %zu LoRAs...\n", lora_specs.size());
-        sd_ctx->sd->kcpp_lora_cache_populate = lora_cache;
-        sd_ctx->sd->apply_loras(lora_specs.data(), lora_specs.size());
-        sd_ctx->sd->kcpp_lora_cache_populate = false;
+        set_lora_cache(sd_ctx, lora_cache);
+        apply_loras(sd_ctx, lora_specs);
+        set_lora_cache(sd_ctx, false);
     }
 
     input_extraimage_buffers.reserve(max_extra_images);
@@ -958,21 +939,17 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
         sd_params->sample_method = sd_get_default_sample_method(sd_ctx);
     }
 
-    sd_ctx->sd->SetCircularAxesAll(inputs.circular_x, inputs.circular_y);
+    SetCircularAxesAll(sd_ctx, inputs.circular_x, inputs.circular_y);
 
     sd_params->cache_mode    = inputs.cache_mode ? inputs.cache_mode : "";
     sd_params->cache_options = inputs.cache_options ? inputs.cache_options : "";
 
-    auto loadedsdver = get_loaded_sd_version(sd_ctx);
+    auto info = get_model_info(sd_ctx);
     bool is_img2img = img2img_data != "";
-    bool is_wan = (loadedsdver == SDVersion::VERSION_WAN2 || loadedsdver == SDVersion::VERSION_WAN2_2_I2V || loadedsdver == SDVersion::VERSION_WAN2_2_TI2V);
-    bool is_qwenimg = (loadedsdver == SDVersion::VERSION_QWEN_IMAGE);
-    bool is_kontext = (loadedsdver==SDVersion::VERSION_FLUX && !loaded_model_is_chroma(sd_ctx));
-    bool is_flux2 = (loadedsdver == SDVersion::VERSION_FLUX2 || loadedsdver == SDVersion::VERSION_FLUX2_KLEIN);
 
-    if (loadedsdver == SDVersion::VERSION_FLUX)
+    if (info.is_flux1)
     {
-        if (!loaded_model_is_chroma(sd_ctx) && sd_params->cfg_scale != 1.0f) {
+        if (!info.is_chroma && sd_params->cfg_scale != 1.0f) {
             //non chroma clamp cfg scale
             if (!sd_is_quiet && sddebugmode) {
                 printf("Flux: clamping CFG Scale to 1\n");
@@ -981,7 +958,7 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
         }
     }
 
-    if(!remove_limits && loadedsdver == SDVersion::VERSION_Z_IMAGE)
+    if(!remove_limits && info.is_zimage)
     {
         if(sd_params->cfg_scale > 4.0f)
         {
@@ -992,7 +969,7 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
         }
     }
 
-    if(loadedsdver == SDVersion::VERSION_SDXS_512_DS || loadedsdver == SDVersion::VERSION_SDXS_09)
+    if(info.is_sdxs)
     {
         if(sd_params->cfg_scale > 1.0f || sd_params->sample_steps > 1)
         {
@@ -1004,7 +981,7 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
         }
     }
 
-    if(is_wan && extra_image_data.size()==0 && is_img2img)
+    if(info.is_wan && extra_image_data.size()==0 && is_img2img)
     {
         extra_image_data.push_back(img2img_data);
     }
@@ -1021,14 +998,14 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
     int hard_megapixel_res_limit = 2048; // hard area limit, no matter the config
     if (cfg_square_limit <= 0) {
         // default limit is model dependent: ~0.66 megapixel for SD1.5/SD2, 1 megapixel for most models
-        img_soft_limit = ((loadedsdver==SDVersion::VERSION_SD1 || loadedsdver==SDVersion::VERSION_SD2)?832:1024);
+        img_soft_limit = (info.is_sd1 || info.is_sd2)?832:1024;
     } else {
         // force img_side_min <= limit <= hard_megapixel_res_limit
         img_soft_limit = std::max(std::min(cfg_square_limit, hard_megapixel_res_limit), img_side_min);
     }
 
     // unet is limited to multiples of 64; dit models vary
-    int spatial_multiple = sd_ctx->sd->get_vae_scale_factor() * sd_ctx->sd->get_diffusion_model_down_factor();
+    int spatial_multiple = info.spatial_multiple;
 
     sd_fix_resolution(sd_params->width, sd_params->height, img_hard_limit, img_soft_limit, spatial_multiple);
     if (inputs.width != sd_params->width || inputs.height != sd_params->height) {
@@ -1074,7 +1051,7 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
         {
             int nx2, ny2, nc2;
             int desiredchannels = 3;
-            if(is_wan)
+            if(info.is_wan)
             {
                 uint8_t * loaded = load_image_from_b64(extra_image_data[i],nx2,ny2,img2imgW,img2imgH,3);
                 if(loaded)
@@ -1088,7 +1065,7 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
                     wan_imgs.push_back(extraimage_reference);
                 }
             }
-            else if(is_qwenimg || is_flux2)
+            else if(info.is_qwenimg || info.is_flux2)
             {
                 uint8_t * loaded = load_image_from_b64(extra_image_data[i],nx2,ny2);
                 if(loaded)
@@ -1122,7 +1099,7 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
                     }
                 }
             }
-            else if (is_kontext || photomaker_enabled)
+            else if (info.is_kontext || photomaker_enabled)
             {
                 uint8_t * loaded = load_image_from_b64(extra_image_data[i],nx2,ny2);
                 if(loaded)
@@ -1133,7 +1110,7 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
                     extraimage_reference.height = ny2;
                     extraimage_reference.channel = desiredchannels;
                     extraimage_reference.data = loaded;
-                    if(is_kontext)
+                    if(info.is_kontext)
                     {
                         reference_imgs.push_back(extraimage_reference);
                     }

--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -19,8 +19,8 @@
 
 // #include "preprocessing.hpp"
 #include "stable-diffusion.h"
-#include "util.h"
 #include "kcpp_sd_extensions.h"
+#include "ggml-backend.h"
 
 using namespace kcpp_sd;
 
@@ -261,8 +261,6 @@ std::string load_umt5_tokenizer_json()
     return umt5str;
 }
 
-void kcpp_sd_set_main_gpu(int value);
-
 bool sdtype_load_model(const sd_load_model_inputs inputs) {
     sd_is_quiet = inputs.quiet;
     set_sd_quiet(sd_is_quiet);
@@ -287,7 +285,7 @@ bool sdtype_load_model(const sd_load_model_inputs inputs) {
     printf("\nImageGen Init - Load Model: %s\n",inputs.model_filename);
 
     //kcpp allow gpu id override
-    kcpp_sd_set_main_gpu(inputs.kcpp_main_gpu);
+    config_main_gpu(inputs.kcpp_main_gpu);
 
     int lora_apply_mode = LORA_APPLY_AT_RUNTIME;
     bool lora_dynamic = false;

--- a/otherarch/sdcpp/stable-diffusion.cpp
+++ b/otherarch/sdcpp/stable-diffusion.cpp
@@ -4205,3 +4205,61 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
 }
 
 
+#include "kcpp_sd_extensions.h"
+
+namespace kcpp_sd {
+
+    static_assert((int)SD_TYPE_COUNT == (int)GGML_TYPE_COUNT,
+            "inconsistency between SD_TYPE_COUNT and GGML_TYPE_COUNT");
+
+    int get_loaded_sd_version(sd_ctx_t* ctx) {
+        return ctx->sd->version;
+    }
+
+    bool loaded_model_is_chroma(sd_ctx_t* ctx) {
+        if (ctx != nullptr && ctx->sd != nullptr) {
+            auto maybe_flux = std::dynamic_pointer_cast<FluxModel>(ctx->sd->diffusion_model);
+            if (maybe_flux != nullptr) {
+                return maybe_flux->flux.flux_params.is_chroma;
+            }
+        }
+        return false;
+    }
+
+    int get_spatial_multiple(sd_ctx_t* ctx) {
+        return ctx->sd->get_vae_scale_factor() * ctx->sd->get_diffusion_model_down_factor();
+    }
+
+    model_info get_model_info(sd_ctx_t* ctx)
+    {
+        model_info res = {};
+        auto loadedsdver = get_loaded_sd_version(ctx);
+        res.is_wan = (loadedsdver == SDVersion::VERSION_WAN2 || loadedsdver == SDVersion::VERSION_WAN2_2_I2V || loadedsdver == SDVersion::VERSION_WAN2_2_TI2V);
+        res.is_qwenimg = (loadedsdver == SDVersion::VERSION_QWEN_IMAGE);
+        res.is_chroma = loaded_model_is_chroma(ctx);
+        res.is_kontext = (loadedsdver==SDVersion::VERSION_FLUX && !res.is_chroma);
+        res.is_flux2 = (loadedsdver == SDVersion::VERSION_FLUX2 || loadedsdver == SDVersion::VERSION_FLUX2_KLEIN);
+        res.is_flux1 = (loadedsdver == SDVersion::VERSION_FLUX);
+        res.is_zimage = (loadedsdver == SDVersion::VERSION_Z_IMAGE);
+        res.is_sdxs = (loadedsdver == SDVersion::VERSION_SDXS_512_DS || loadedsdver == SDVersion::VERSION_SDXS_09);
+        res.is_sd1 = (loadedsdver == SDVersion::VERSION_SD1);
+        res.is_sd2 = (loadedsdver == SDVersion::VERSION_SD2);
+        res.spatial_multiple = get_spatial_multiple(ctx);
+        return res;
+    }
+
+    void SetCircularAxesAll(sd_ctx_t* ctx, bool circular_x, bool circular_y) {
+        ctx->sd->SetCircularAxesAll(circular_x, circular_y);
+    }
+
+    void set_lora_cache(sd_ctx_t *ctx, bool enable) {
+        ctx->sd->kcpp_lora_cache_populate = enable;
+    }
+
+    void apply_loras(sd_ctx_t *ctx, const std::vector<sd_lora_t>& lora_specs)
+    {
+        ctx->sd->apply_loras(lora_specs.data(), lora_specs.size());
+    }
+
+}
+

--- a/otherarch/sdcpp/util.cpp
+++ b/otherarch/sdcpp/util.cpp
@@ -463,18 +463,6 @@ void log_message(const char* format, ...) {
         fflush(stdout);
     }
 }
-void set_sd_log_level(int log)
-{
-    sdloglevel = log;
-}
-bool get_sd_log_level()
-{
-    return sdloglevel;
-}
-void set_sd_quiet(bool quiet)
-{
-    sdquiet = quiet;
-}
 
 void log_printf(sd_log_level_t level, const char* file, int line, const char* format, ...) {
     va_list args;
@@ -747,8 +735,20 @@ bool sd_backend_is(ggml_backend_t backend, const std::string& name) {
     return dev_name.find(name) != std::string::npos;
 }
 
+#include "kcpp_sd_extensions.h"
+
+void kcpp_sd::set_sd_quiet(bool quiet)
+{
+    sdquiet = quiet;
+}
+
+void kcpp_sd::set_sd_log_level(int log)
+{
+    sdloglevel = log;
+}
+
 static int kcpp_main_gpu = -1;
-void kcpp_sd_set_main_gpu(int value) {
+void kcpp_sd::config_main_gpu(int value) {
     ggml_backend_load_all_once();
     if (value >= 0) {
         size_t dev_count = ggml_backend_dev_count();

--- a/otherarch/sdcpp/util.h
+++ b/otherarch/sdcpp/util.h
@@ -91,9 +91,6 @@ bool sd_backend_is(ggml_backend_t backend, const std::string& name);
 ggml_backend_t sd_get_default_backend();
 
 void log_message(const char* format, ...);
-void set_sd_log_level(int log);
-bool get_sd_log_level();
-void set_sd_quiet(bool quiet);
 #define LOG_DEBUG(...)  log_message(__VA_ARGS__)
 #define LOG_INFO(...)  log_message(__VA_ARGS__)
 #define LOG_WARN(...)  log_message(__VA_ARGS__)


### PR DESCRIPTION
Use Makefile rules to build each sd .cpp source file separately, and create the corresponding object lists dynamically.

I've added an extra header to serve as a 'bridge' between sdtype_adapter.cpp and stable-diffusion.cpp internals, so the former now only depends on the public API and the extension functions. This way, all sd source files can be built without changes, and reused by the sdmain binary.

Additional sources will only need to be included in the appropriate source list (one for Koboldcpp, another for sdmain only). As an added benefit, the build should be faster now, since the individual sources are simpler than the bundle, and can be built in parallel.

This will likely conflict with #2184 , but rebasing should be fairly simple.