### PR TITLE
fix(reload): preserve empty-list values in admin reload (#2190)

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -9516,7 +9516,11 @@ def reload_new_config(filename,defaultargs,overwrite_blank=False): #for changing
             for key, value in defaultargs.items():   # Fill missing defaults directly into config
                 if key not in config:
                     config[key] = value
-                elif overwrite_blank and key in config and not config[key]:
+                elif overwrite_blank and key in config and (config[key] is None or config[key] == ""):
+                    # Only treat None/empty-string as blank. Empty list/0/False are
+                    # intentional (e.g. usevulkan=[] means "use Vulkan, autodetect
+                    # device"); replacing them with the default would silently flip
+                    # the backend to CPU. See issue #2190.
                     config[key] = value
             reload_from_new_args(config)
         except Exception as e:


### PR DESCRIPTION
## Summary

Closes #2190.

When the admin UI reloads a config (`POST /api/admin/reload_config`), the merge inside `reload_new_config` used `not config[key]` to detect "blank" values that should be filled from defaults:

```python
elif overwrite_blank and key in config and not config[key]:
    config[key] = value  # <- value here is the default (None for usevulkan)
```

`not config[key]` is `True` for **`[]`, `0`, `False`** in addition to `None` / `""`. For multi-value backend flags like `--usevulkan` and `--usecuda` (`nargs='*'`, `default=None`), an **empty list `[]` is meaningful** — it means *"use this backend, auto-detect GPU(s)"*. After the buggy merge, an explicit `"usevulkan": []` from a `.kcpps` preset got overwritten back to `None`, which the dispatch in `pick_existant_file()` (line ~853) interprets as *"no GPU acceleration"*, so `koboldcpp_default.so` was loaded and the model fell back to CPU.

Repro from the issue:

> Cold start `Namespace: usevulkan=[]` → loads `koboldcpp_vulkan.so`, GPU used
> Internal reload `Namespace: usevulkan=None` → loads `koboldcpp_default.so`, CPU fallback

The cold start works because `load_config_cli` uses `setattr(args, key, value)` directly (no `overwrite_blank` step). Only the admin reload path triggers the bug.

## Fix

Tighten the blank check to `config[key] is None or config[key] == ""`. Empty lists, zeros, and `False` are now preserved, so `usevulkan=[]` survives the reload. None/empty-string still get filled from defaults, so existing behavior for missing string fields is unchanged.

```python
elif overwrite_blank and key in config and (config[key] is None or config[key] == ""):
    config[key] = value
```

## Test plan

- [x] Local repro: a `.kcpps` preset with `"usevulkan": []` loaded via admin reload now keeps `args.usevulkan == []` (verified by inspecting `Namespace` after reload). The dispatch correctly loads `koboldcpp_vulkan.so`.
- [x] Verified `usecuda=[]` and other empty-list flags survive the same way.
- [x] Verified `"path": ""` and missing keys still get default-filled (no regression).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
