### PR TITLE
Fix jinja error on case-insensitive roles and 0-len messages result

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -3510,11 +3510,11 @@ def format_jinja(messages_orig, tools, chat_template_kwargs=None):
         assist_should_prefill = False
         chat_template_kwargs = chat_template_kwargs or {}
         last_assist_msg = ""
-        if len(messages) > 1:
+        if messages:
             last_assist_msg = messages[-1]["content"]
             assist_should_prefill = (messages and messages[-1]["role"].lower() == "assistant" and last_assist_msg and isinstance(last_assist_msg, str) and len(last_assist_msg.strip())>0) #avoid single character newline or space content
             last_assist_msg = "" if not assist_should_prefill else last_assist_msg
-            messages_for_render = messages[:-1] if assist_should_prefill else messages
+            messages_for_render = messages[:-1] if len(messages) > 1 and assist_should_prefill else messages
         if tools and len(tools)>0:
             text = jinja_compiled_template.render(messages=messages_for_render, tools=tools, add_generation_prompt=True, bos_token="", eos_token="", **chat_template_kwargs)
         else:

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -3510,9 +3510,9 @@ def format_jinja(messages_orig, tools, chat_template_kwargs=None):
         assist_should_prefill = False
         chat_template_kwargs = chat_template_kwargs or {}
         last_assist_msg = ""
-        if messages:
+        if len(messages) > 1:
             last_assist_msg = messages[-1]["content"]
-            assist_should_prefill = (messages and messages[-1]["role"] == "assistant" and last_assist_msg and isinstance(last_assist_msg, str) and len(last_assist_msg.strip())>0) #avoid single character newline or space content
+            assist_should_prefill = (messages and messages[-1]["role"].lower() == "assistant" and last_assist_msg and isinstance(last_assist_msg, str) and len(last_assist_msg.strip())>0) #avoid single character newline or space content
             last_assist_msg = "" if not assist_should_prefill else last_assist_msg
             messages_for_render = messages[:-1] if assist_should_prefill else messages
         if tools and len(tools)>0:


### PR DESCRIPTION
Code is not detecting "Assistant" from ST.

When it is fixed, Jinja template errors consistently if there is only 1 assistant message, due to `Jinja formatting failed: list object has no element 0`

Both fixed