### PR TITLE
sd: adjust VAE tile size according to sdtiledvae

### DIFF
--- a/otherarch/sdcpp/kcpp_sd_extensions.h
+++ b/otherarch/sdcpp/kcpp_sd_extensions.h
@@ -17,6 +17,7 @@ namespace kcpp_sd {
         bool is_sdxs;
         bool is_wan;
         bool is_zimage;
+        int vae_scale_factor;
         int spatial_multiple;
     };
 

--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -1043,6 +1043,16 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
     // trigger tiling by image area, the memory used for the VAE buffer is 6656 bytes per image pixel, default 768x768
     bool dotile = (sd_params->width*sd_params->height > cfg_tiled_vae_threshold*cfg_tiled_vae_threshold);
 
+    int vae_tile_size = -1;
+    if (dotile) {
+        int new_vae_tile_size = cfg_tiled_vae_threshold / info.vae_scale_factor;
+        new_vae_tile_size = new_vae_tile_size / 2;
+        new_vae_tile_size -= new_vae_tile_size % 2;
+        if (new_vae_tile_size > vae_tile_size) {
+            vae_tile_size = new_vae_tile_size;
+        }
+    }
+
     //for img2img
     sd_image_t input_image = {0,0,0,nullptr};
     std::vector<sd_image_t> reference_imgs;
@@ -1193,6 +1203,10 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
     params.seed = sd_params->seed;
     params.strength = sd_params->strength;
     params.vae_tiling_params.enabled = dotile;
+    if (vae_tile_size > 0) {
+        params.vae_tiling_params.tile_size_x = vae_tile_size;
+        params.vae_tiling_params.tile_size_y = vae_tile_size;
+    }
     parse_cache_options(params.cache, sd_params->cache_mode, sd_params->cache_options);
 
     LoraMap lora_map = sd_params->lora_map;

--- a/otherarch/sdcpp/stable-diffusion.cpp
+++ b/otherarch/sdcpp/stable-diffusion.cpp
@@ -4464,6 +4464,7 @@ namespace kcpp_sd {
         res.is_sdxs = (loadedsdver == SDVersion::VERSION_SDXS_512_DS || loadedsdver == SDVersion::VERSION_SDXS_09);
         res.is_sd1 = (loadedsdver == SDVersion::VERSION_SD1);
         res.is_sd2 = (loadedsdver == SDVersion::VERSION_SD2);
+        res.vae_scale_factor = ctx->sd->get_vae_scale_factor();
         res.spatial_multiple = get_spatial_multiple(ctx);
         return res;
     }


### PR DESCRIPTION
I forgot to send this one. The idea is changing the VAE tile size to use a specific fraction of the non-tiled VAE image limit: larger tiles tend to be faster, and avoid artifacts (since the model has more image context to work with).

For instance, in the default SDXL config (768x768), it increases the tile size from 32x32 to 48x48, which for SDXL resolutions is ~30% faster.

In principle, we could use any ratio, but values close to 1 are problematic because images a bit above the threshold could take almost four times longer than right at the threshold (non-tiles -> 4 tiles for a square image). In my tests, 2/3 worked fine, too; the current 1/2 is a bit more conservative.

Leaving it as draft for now, because I know we are close to the next release, and this isn't exactly a priority.