### PR TITLE
sd: device selection fixes and improvements

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -8832,8 +8832,8 @@ def show_gui():
         args.sdmodel = sd_model_var.get() if sd_model_var.get() != "" else ""
         args.sdflashattention = True if sd_flash_attention_var.get()==1 else False
         args.sdoffloadcpu = True if sd_offload_cpu_var.get()==1 else False
-        args.sdvaedevice = sd_resolve_device(sd_vae_device_var.get(), -1)
-        args.sdclipdevice = sd_resolve_device(sd_clip_device_var.get(), -1)
+        args.sdvaedevice = sd_resolve_device(sd_vae_device_var.get())
+        args.sdclipdevice = sd_resolve_device(sd_clip_device_var.get())
         args.sdthreads = (0 if sd_threads_var.get()=="" else int(sd_threads_var.get()))
         args.sdclamped = (0 if int(sd_clamped_var.get())<=0 else int(sd_clamped_var.get()))
         args.sdclampedsoft = (0 if int(sd_clamped_soft_var.get())<=0 else int(sd_clamped_soft_var.get()))
@@ -9121,8 +9121,8 @@ def show_gui():
         sd_quant_var.set(sd_quant_choices[(mydict["sdquant"] if ("sdquant" in mydict and mydict["sdquant"]>=0 and mydict["sdquant"]<len(sd_quant_choices)) else 0)])
         sd_flash_attention_var.set(1 if ("sdflashattention" in mydict and mydict["sdflashattention"]) else 0)
         sd_offload_cpu_var.set(1 if ("sdoffloadcpu" in mydict and mydict["sdoffloadcpu"]) else 0)
-        sd_vae_device_var.set(sd_get_device_name(sd_resolve_device(mydict.get("sdvaedevice"), default_sdvaedevice), 1))
-        sd_clip_device_var.set(sd_get_device_name(sd_resolve_device(mydict.get("sdclipdevice"), default_sdclipdevice), 1))
+        sd_vae_device_var.set(sd_get_device_name(sd_resolve_device(mydict.get("sdvaedevice"), default_sdvaedevice)))
+        sd_clip_device_var.set(sd_get_device_name(sd_resolve_device(mydict.get("sdclipdevice"), default_sdclipdevice)))
         sd_convdirect_var.set(sd_convdirect_option(mydict.get("sdconvdirect")))
         sd_vae_var.set(mydict["sdvae"] if ("sdvae" in mydict and mydict["sdvae"]) else "")
         sd_t5xxl_var.set(mydict["sdt5xxl"] if ("sdt5xxl" in mydict and mydict["sdt5xxl"]) else "")

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2403,8 +2403,9 @@ def sd_quant_option(value):
 
 sd_device_choices = ['CPU', 'main', '0', '1', '2', '3']
 
-def sd_get_device_number(name, offset=0):
-    if name is None: # default handling should be done elsewhere
+def sd_get_device_number(name):
+    '''maps device name to device number'''
+    if name is None: # default handling should be done by sd_resolve_device
         return None
     if not name:
         return -1
@@ -2412,21 +2413,23 @@ def sd_get_device_number(name, offset=0):
     aliases = {"cpu": -2, "gpu": -1, "": -1, "main": -1, "default": -1}
     if name in aliases:
         return aliases[name]
-    return tryparseint(name, -1) + offset
+    return tryparseint(name, -1)
 
-def sd_get_device_name(value, offset=0):
+def sd_get_device_name(value):
+    '''maps device number to device name'''
     if value <= -2:
         return "CPU"
     if value == -1:
         return "main"
-    return value + offset
+    return str(value)
 
-def sd_resolve_device(name, default_=-1, offset=0):
+def sd_resolve_device(name, default_=-1):
+    '''maps device name to device number, handling the default device'''
     if name is None:
         name = default_
     if isinstance(name, int):
         name = str(max(name, -2))
-    return sd_get_device_number(name, offset=offset)
+    return sd_get_device_number(name)
 
 def sd_load_model(model_filename,vae_filename,t5xxl_filename,clip1_filename,clip2_filename,photomaker_filename,upscaler_filename):
     global args

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -7662,7 +7662,7 @@ def show_gui():
     sd_clamped_soft_var = ctk.StringVar(value="0")
     sd_threads_var = ctk.StringVar(value=str(default_threads))
     sd_quant_var = ctk.StringVar(value=sd_quant_choices[0])
-    sd_main_gpu_var = ctk.StringVar(value="-1")
+    sd_main_gpu_var = ctk.StringVar(value="main")
 
     gen_defaults_var = ctk.StringVar()
     gen_defaults_overwrite_var = ctk.IntVar(value=0)
@@ -8486,8 +8486,8 @@ def show_gui():
     makelabelentry(images_tab, "(Soft):", sd_clamped_soft_var, 14, 50, padx=(250),singleline=True,tooltip="Square image size restriction, to protect the server against memory crashes.\nAllows width-height tradeoffs, eg. 640 allows 640x640 and 512x768\nLeave at 0 for the default value: 832 for SD1.5/SD2, 1024 otherwise.",labelpadx=(210))
     makecheckbox(images_tab, "Runtime LoRAs", sd_runtime_loras_var, 14,command=togglesdlora, padx=(310), tooltiptxt="Allow using LoRAs in a directory dynamically (syntax is <lora:name:weight>)")
 
-    makelabelentry(images_tab, "ImgThreads:" , sd_threads_var, 8, 40,padx=(280),singleline=True,tooltip="How many threads to use during image generation.\nIf left blank, uses same value as threads.",labelpadx=(200))
-    makelabelentry(images_tab, "ImgGPU:" , sd_main_gpu_var, 8, 40,padx=394,singleline=True,tooltip="Which GPU ID to use for Image Gen?\nIf left blank or -1, uses default value.",labelpadx=340)
+    makelabelentry(images_tab, "ImgThreads:" , sd_threads_var, 8, 40,padx=(275),singleline=True,tooltip="How many threads to use during image generation.\nIf left blank, uses same value as threads.",labelpadx=(195))
+    makelabelcombobox(images_tab, "ImgGPU:" , sd_main_gpu_var, 8, width=70,padx=375,tooltiptxt="Which device to use for Image Gen?\nIf left blank or 'main', uses the main device.",labelpadx=320, values=sd_device_choices)
     sd_model_var.trace_add("write", gui_changed_modelfile)
     makelabelcombobox(images_tab, "Compress Weights: ", sd_quant_var, 8, width=(60), padx=(126), labelpadx=8, tooltiptxt="Quantizes the SD model weights to save memory.\nHigher levels save more memory, and cause more quality degradation.", values=sd_quant_choices)
     sd_quant_var.trace_add("write", changed_gpulayers_estimate)
@@ -8859,7 +8859,7 @@ def show_gui():
         args.sdlora = [item.strip() for item in sd_lora_var.get().split("|") if item]
         # XXX the user may have used '|' since it's used for the LoRAs
         args.sdloramult = sanitize_lora_multipliers(re.split(r"[ |]+", sd_loramult_var.get()))
-        args.sdmaingpu = (-1 if sd_main_gpu_var.get()=="" else int(sd_main_gpu_var.get()))
+        args.sdmaingpu = sd_resolve_device(sd_main_gpu_var.get())
         args.gendefaults = gen_defaults_var.get()  if gen_defaults_var.get() != "" else ""
         args.gendefaultsoverwrite = (gen_defaults_overwrite_var.get()==1)
         args.whispermodel = whisper_model_var.get() if whisper_model_var.get() != "" else ""
@@ -9138,10 +9138,7 @@ def show_gui():
         sdl_sanitized = sanitize_lora_list(mydict.get('sdlora'))
         sd_lora_var.set("|".join(sdl_sanitized))
         sd_loramult_var.set(" ".join(f"{n:.3f}".rstrip('0').rstrip('.') for n in mydict.get("sdloramult", [])))
-        if "sdmaingpu" in mydict:
-            sd_main_gpu_var.set(mydict["sdmaingpu"])
-        else:
-            sd_main_gpu_var.set("-1")
+        sd_main_gpu_var.set(sd_get_device_name(sd_resolve_device(mydict.get("sdmaingpu"))))
         if sdl_sanitized and len(sdl_sanitized)==1 and os.path.isdir(sdl_sanitized[0]):
             sd_runtime_loras_var.set(1)
         else:
@@ -11648,8 +11645,8 @@ if __name__ == '__main__':
     sdparsergroup.add_argument("--sdupscaler", metavar=('[filename]'), help="You can use ESRGAN as an upscaling model to resize images. Leave blank if unused.", default="")
     sdparsergroup.add_argument("--sdflashattention", help="Enables Flash Attention for image generation.", action='store_true')
     sdparsergroup.add_argument("--sdoffloadcpu", help="Offload image weights in RAM to save VRAM, swap into VRAM when needed.", action='store_true')
-    sdparsergroup.add_argument("--sdvaedevice", help=f"VAE device for image generation. GPU index, -1 or 'main' for the main GPU, or 'CPU' (default: {default_sdvaedevice}).", type=sd_get_device_number, default=None)
-    sdparsergroup.add_argument("--sdclipdevice", help=f"CLIP / T5 / LLM device for image generation. GPU index, -1 or 'main' for the main GPU, or 'CPU' (default: {default_sdclipdevice}).", type=sd_get_device_number, default=None)
+    sdparsergroup.add_argument("--sdvaedevice", metavar=('[Device ID]'), help=f"VAE device for image generation. GPU index, -1 or 'main' for the main GPU, or 'CPU' (default: {default_sdvaedevice}).", type=sd_get_device_number, default=None)
+    sdparsergroup.add_argument("--sdclipdevice", metavar=('[Device ID]'), help=f"CLIP / T5 / LLM device for image generation. GPU index, -1 or 'main' for the main GPU, or 'CPU' (default: {default_sdclipdevice}).", type=sd_get_device_number, default=None)
     sdparsergroup.add_argument("--sdconvdirect", help="Enables Conv2D Direct. May improve performance or reduce memory usage. Might crash if not supported by the backend. Can be 'off' (default) to disable, 'full' to turn it on for all operations, or 'vaeonly' to enable only for the VAE.", type=sd_convdirect_option, choices=sd_convdirect_choices, default=sd_convdirect_choices[0])
     sdparsergroupvae = sdparsergroup.add_mutually_exclusive_group()
     sdparsergroupvae.add_argument("--sdvae", metavar=('[filename]'), help="Specify an image generation safetensors VAE which replaces the one in the model.", default="")


### PR DESCRIPTION
Not sure if you were able to remove the offsets already, but I've got some time here, so...

I've also added some docs to the functions, and adapted the sdmaingpu control to use the same approach as the other ones. BTW, maybe ImgThreads and ImgGPU could be renamed to Threads and GPU (or Device) to save some space, since 'Img' is implicit because it's the Image Generation tab?