### PR TITLE
Draft - Implement configurable MP3 bitrate

### DIFF
--- a/embd_res/kcpp_musicui.embd
+++ b/embd_res/kcpp_musicui.embd
@@ -239,7 +239,7 @@ select{
       <div><label>Steps</label><input title="Generation Steps" id="inference_steps" type="number" value="8"></div>
       <div><label>Guidance</label><input title="Guidance Scale" id="guidance_scale" type="number" value="1"></div>
       <div><label>Shift</label><input title="Audio Shift" id="shift" type="number" value="3"></div>
-      <div><label>Save as MP3</label><input title="Save as MP3" id="use_mp3" type="checkbox"></div>
+      <div><label>Save as MP3</label><input title="Save as MP3" id="use_mp3" type="checkbox" onchange="document.getElementById('kbps').disabled=!this.checked"><select id="kbps" disabled><option value="64">64 kbps</option><option value="96">96 kbps</option><option value="128" selected>128 kbps</option><option value="160">160 kbps</option><option value="192">192 kbps</option><option value="256">256 kbps</option><option value="320">320 kbps</option></select></div>
       <div><label>Stereo</label><input title="Save as Stereo" id="stereo" type="checkbox" checked></div>
       <div><label>Gen Codes</label><input title="Generate Audio Codes" id="gen_codes" type="checkbox"></div>
       <div><label>Plan with LLM</label><input title="Plan with LLM" id="plan_with_main_llm" type="checkbox"></div>
@@ -538,6 +538,8 @@ function getFormData(){
   });
   data["stereo"] = (document.getElementById("stereo").checked ? true : false);
   data["use_mp3"] = (document.getElementById("use_mp3").checked ? true : false);
+  const kbpsEl = document.getElementById("kbps");
+  data["kbps"] = kbpsEl.disabled ? 128 : Number(kbpsEl.value);
   data["gen_codes"] = (document.getElementById("gen_codes").checked ? true : false);
   data["rewrite_caption"] = (document.getElementById("rewrite_caption").checked ? true : false);
   return data;

--- a/expose.h
+++ b/expose.h
@@ -364,6 +364,7 @@ struct music_generation_inputs
     const bool is_planner_mode = false; //if true, generate codes, else, generate diffusion music
     const bool stereo = false; //only for wav
     const bool use_mp3 = false;
+    const int  kbps = 128;
     const bool gen_codes = false;
     const bool rewrite_caption = true;
     const char * input_json = nullptr;

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -529,6 +529,7 @@ class music_generation_inputs(ctypes.Structure):
     _fields_ = [("is_planner_mode", ctypes.c_bool),
                 ("stereo", ctypes.c_bool),
                 ("use_mp3", ctypes.c_bool),
+                ("kbps", ctypes.c_int),
                 ("gen_codes", ctypes.c_bool),
                 ("rewrite_caption", ctypes.c_bool),
                 ("input_json", ctypes.c_char_p),
@@ -3071,6 +3072,7 @@ def music_generate_audio(genparams):
     inputs.is_planner_mode = False
     inputs.stereo = genparams.get('stereo', True)
     inputs.use_mp3 = genparams.get('use_mp3', False)
+    inputs.kbps = genparams.get('kbps', 128)
     inputs.gen_codes =  genparams.get('gen_codes', False)
     inputs.rewrite_caption =  genparams.get('rewrite_caption', True)
     inputs.input_json = input_json.encode("UTF-8")

--- a/otherarch/acestep/dit-vae.cpp
+++ b/otherarch/acestep/dit-vae.cpp
@@ -618,7 +618,7 @@ std::string acestep_generate_audio(const music_generation_inputs inputs)
     std::string finalb64;
     if (inputs.use_mp3) {
         fprintf(stderr, "[Save Audio] Converting to Mp3 (CPU based, may be slow, use .wav if too slow)...\n",muslen);
-        finalb64 = save_stereo_mp3_base64(audio, T_audio, 48000);
+        finalb64 = save_stereo_mp3_base64(audio, T_audio, 48000, inputs.kbps);
     } else if (inputs.stereo) {
          fprintf(stderr, "[Save Audio] Save as Stereo WAV...\n",muslen);
         finalb64 = save_stereo_wav16_base64(audio, T_audio, 48000);

--- a/otherarch/utils.cpp
+++ b/otherarch/utils.cpp
@@ -627,7 +627,7 @@ std::string save_stereo_wav16_base64(const std::vector<float> & raw_audio, int T
     return kcpp_base64_encode(wav_data);
 }
 
-std::string save_stereo_mp3_base64(const std::vector<float> & raw_audio,int T_audio,int sample_rate) {
+std::string save_stereo_mp3_base64(const std::vector<float> & raw_audio,int T_audio,int sample_rate,int bitrate_kbps) {
     const float * enc_audio = raw_audio.data();
     int enc_T  = T_audio;
     int enc_sr = sample_rate;
@@ -641,7 +641,10 @@ std::string save_stereo_mp3_base64(const std::vector<float> & raw_audio,int T_au
         enc_T     = (int)resampled.size() / 2;
     }
 
-    const int kbps = 128;
+    int kbps = bitrate_kbps;
+    // Clamp to valid MPEG1 bitrate range
+    if (kbps < 32) kbps = 32;
+    if (kbps > 320) kbps = 320;
 
     // Encode PCM [offset, offset+len) with optional warm-up.
     // warmup=true primes filterbank/MDCT/psy with the 1152 PCM samples

--- a/otherarch/utils.h
+++ b/otherarch/utils.h
@@ -112,4 +112,4 @@ struct wav_ulaw_header {
 std::string save_ulaw_wav8_base64(const std::vector<float> &data, int sample_rate);
 std::string save_wav16_base64(const std::vector<float> &data, int sample_rate);
 std::string save_stereo_wav16_base64(const std::vector<float> & raw_audio, int T_audio, int sample_rate);
-std::string save_stereo_mp3_base64(const std::vector<float> & raw_audio,int T_audio,int sample_rate);
+std::string save_stereo_mp3_base64(const std::vector<float> & raw_audio,int T_audio,int sample_rate,int bitrate_kbps = 128);


### PR DESCRIPTION
First draft of implementing a dropdown for setting the MP3 bitrate, rather than using a hardcoded value of 128. 
<img width="1131" height="932" alt="image" src="https://github.com/user-attachments/assets/83cb17b6-e699-4ed2-924d-f5c59feec49e" />

<!--StartFragment--><p style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 12px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; color: rgb(237, 237, 237); font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(21, 21, 21); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Here's a summary of all changes:</p>
File | Change
-- | --
expose.h:367 | Added const int kbps = 128 to music_generation_inputs
koboldcpp.py:532 | Added ("kbps", ctypes.c_int) to Python struct (matching C++ layout)
koboldcpp.py:3075 | Added inputs.kbps = genparams.get('kbps', 128) in music_generate_audio()
utils.h:115 | Added int bitrate_kbps = 128 to save_stereo_mp3_base64 signature
utils.cpp:644-647 | Replaced const int kbps = 128 with kbps = bitrate_kbps + clamping to [32, 320]
dit-vae.cpp:621 | Passes inputs.kbps to save_stereo_mp3_base64
kcpp_musicui.embd:242 | Added <select> dropdown (64/96/128/160/192/256/320 kbps), disabled until MP3 checkbox checked
kcpp_musicui.embd:541-542 | Added kbps to getFormData(), reads dropdown value or defaults to 128 when disabled

<p style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; color: rgb(237, 237, 237); font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(21, 21, 21); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The encoder (<code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(0, 206, 185); font-weight: 500; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">mp3enc.h</code>) already supports all bitrates 32-320 kbps via its internal lookup table — no changes needed there. The dropdown defaults to 128 (the original hardcoded value) when MP3 is unchecked, so existing behavior is preserved.</p><!--EndFragment-->

[A dreamy, arpeggiated electric 320kbps.mp3](https://github.com/user-attachments/files/28328309/A.dreamy.arpeggiated.electric.320kbps.mp3)
[A dreamy, arpeggiated electric 128kbps.mp3](https://github.com/user-attachments/files/28328311/A.dreamy.arpeggiated.electric.128kbps.mp3)
