### PR TITLE
Update README to mention Kobold2PDF project

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,7 @@ and it will install everything required. Alternatively, you can download the abo
   - Image Recognition MMproj: [Pick the correct one for your model architecture here](https://huggingface.co/koboldcpp/mmproj/tree/main)
   - Speech Recognition: [Whisper models for Speech-To-Text](https://huggingface.co/koboldcpp/whisper/tree/main)
   - Text-To-Speech: [TTS models for Narration](https://huggingface.co/koboldcpp/tts/tree/main)
+
+# Export formats
+
+- @SuperCowProducts has worked on a bash script (JSON->Markdown->PDF) for this task: [Kobold2PDF](https://codeberg.org/jipmelon/Kobold2PDF) - feature-incomplete, open to contributions


### PR DESCRIPTION
This might be helpful to users who want to export their conversations into a human-readable format, as I have not been able to find any other software that did this the way I wanted: at least they have somewhere to start if they want to do something similar.

I'm sure any developer could do a better job than my bash script but it worked fine for the first simple conversion task I gave it (`example.json`).