### PR TITLE
sd: fix utf-8 prompt handling

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2761,16 +2761,12 @@ def sd_generate(genparams):
 
     prompt = genparams.get("prompt", "high quality")
     negative_prompt = genparams.get("negative_prompt", "")
-    if forced_negprompt!="":
-        if negative_prompt!="":
-            negative_prompt += ", " + forced_negprompt
-        else:
-            negative_prompt = forced_negprompt
-    if forced_posprompt!="":
-        if prompt!="":
-            prompt += ", " + forced_posprompt
-        else:
-            prompt = forced_posprompt
+    def build_prompt(prompt, forced):
+        # truncate before the forced prompt to ensure it can't be "pushed away" by long inputs
+        prompt = prompt.encode('utf-8')[:2048].decode("UTF-8", errors='ignore')
+        return ", ".join([prompt, forced])
+    prompt = build_prompt(prompt, forced_posprompt)
+    negative_prompt = build_prompt(negative_prompt, forced_negprompt)
     init_images_arr = genparams.get("init_images", [])
     init_images = ("" if (not init_images_arr or len(init_images_arr)==0 or not init_images_arr[0]) else init_images_arr[0])
     init_images = strip_base64_prefix(init_images)

--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -580,20 +580,6 @@ static std::string friendly_model_name(std::filesystem::path model_path) {
     return model_path.filename().string();
 }
 
-std::string clean_input_prompt(const std::string& input) {
-    std::string result;
-    result.reserve(input.size());
-    for (char ch : input) {
-        // Check if the character is an ASCII or extended ASCII character
-        if (static_cast<unsigned char>(ch) <= 0x7F || (ch >= 0xC2 && ch <= 0xF4)) {
-            result.push_back(ch);
-        }
-    }
-    //limit to max 2048 chars
-    result = result.substr(0, 2048);
-    return result;
-}
-
 static std::string get_scheduler_name(scheduler_t scheduler, bool as_sampler_suffix = false)
 {
     if (scheduler == scheduler_t::SCHEDULER_COUNT) {
@@ -988,9 +974,6 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
     }
     sd_image_t * results = nullptr;
 
-    //sanitize prompts, remove quotes and limit lengths
-    std::string cleanprompt = clean_input_prompt(inputs.prompt);
-    std::string cleannegprompt = clean_input_prompt(inputs.negative_prompt);
     std::string img2img_data = std::string(inputs.init_images);
     std::string img2img_mask = std::string(inputs.mask);
     std::vector<std::string> extra_image_data;
@@ -999,8 +982,8 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
         extra_image_data.push_back(std::string(inputs.extra_images[i]));
     }
 
-    sd_params->prompt = cleanprompt;
-    sd_params->negative_prompt = cleannegprompt;
+    sd_params->prompt = inputs.prompt;
+    sd_params->negative_prompt = inputs.negative_prompt;
     sd_params->cfg_scale = inputs.cfg_scale;
     sd_params->distilled_guidance = inputs.distilled_guidance;
     sd_params->sample_steps = inputs.sample_steps;


### PR DESCRIPTION
The `clean_input_prompt` function didn't handle utf-8 multibyte sequences correctly; for instance, "€" expands to {0xe2, 0x82, 0xac}, which would be filtered to {0xe2}.

Although we could fix the C++ implementation, when a forced prompt is configured, a long prompt could be used to remove it; so I've moved that logic to the Python layer. I'm intentionally not applying the limit to the forced part just for simplicity, but I could make it more strict if you wish.

By the way, the comment said "remove quotes", but the code wasn't really doing that...