### PR TITLE
mtmd: fix non-Windows build

### DIFF
--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -1,18 +1,10 @@
-// fix problem with std::min and std::max
-#if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#   define NOMINMAX
-#endif
-#include <windows.h>
-#endif
-
 #include "mtmd.h"
 #include "mtmd-helper.h"
 #include "llama.h"
 
 #include <algorithm>
 #include <cinttypes>
+#include <cstring>
 #include <vector>
 
 //#define MTMD_AUDIO_DEBUG


### PR DESCRIPTION
I was getting:

```
tools/mtmd/mtmd-helper.cpp: In function 'bool audio_helpers::is_audio_file(const char*, size_t)':
tools/mtmd/mtmd-helper.cpp:428:19: error: 'memcmp' was not declared in this scope
  428 |     bool is_wav = memcmp(buf, "RIFF", 4) == 0 && memcmp(buf + 8, "WAVE", 4) == 0;
      |                   ^~~~~~
tools/mtmd/mtmd-helper.cpp:34:1: note: 'memcmp' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
   33 | #include "stb/stb_image.h"
  +++ |+#include <cstring>
   34 | 
tools/mtmd/mtmd-helper.cpp: In function 'mtmd_bitmap* mtmd_helper_bitmap_init_from_file(mtmd_context*, const char*)':
tools/mtmd/mtmd-helper.cpp:515:56: error: 'strerror' was not declared in this scope; did you mean 'stderr'?
  515 |         LOG_ERR("Unable to open file %s: %s\n", fname, strerror(errno));
      |                                                        ^~~~~~~~
tools/mtmd/mtmd-helper.cpp:84:57: note: in definition of macro 'LOG_ERR'
   84 | #define LOG_ERR(...) g_logger.log(GGML_LOG_LEVEL_ERROR, __VA_ARGS__)
      |                                                         ^~~~~~~~~~~
```

The file doesn't seem to depend on any Windows-specific code, so I've removed that part too (but I can't test Windows builds).