### PR TITLE
refactor: add new module for backend-specific code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -617,10 +617,6 @@ ggml-backend-reg_cublas.o: ggml/src/ggml-backend-reg.cpp ggml/src/ggml-backend-i
 	$(CXX)  $(CXXFLAGS) $(CUBLAS_FLAGS) $(HIPFLAGS) -c $< -o $@
 clip_default.o: tools/mtmd/clip.cpp tools/mtmd/clip.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
-clip_cublas.o: tools/mtmd/clip.cpp tools/mtmd/clip.h
-	$(CXX) $(CXXFLAGS) $(CUBLAS_FLAGS) $(HIPFLAGS) -c $< -o $@
-clip_vulkan.o: tools/mtmd/clip.cpp tools/mtmd/clip.h
-	$(CXX) $(CXXFLAGS) $(VULKAN_FLAGS) -c $< -o $@
 
 #rpc
 ggml-rpc.o: ggml/src/ggml-rpc/ggml-rpc.cpp ggml/include/ggml-rpc.h ggml/src/ggml-rpc/transport.h
@@ -730,10 +726,6 @@ LLAMASERVER_CXXFLAGS := -I./tools/mtmd
 #whisper objects
 whispercpp_default.o: otherarch/whispercpp/whisper_adapter.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
-whispercpp_vulkan.o: otherarch/whispercpp/whisper_adapter.cpp
-	$(CXX) $(CXXFLAGS) $(VULKAN_FLAGS) -c $< -o $@
-whispercpp_cublas.o: otherarch/whispercpp/whisper_adapter.cpp
-	$(CXX) $(CXXFLAGS) $(CUBLAS_FLAGS) $(HIPFLAGS) -c $< -o $@
 
 #tts objects
 tts_default.o: otherarch/tts_adapter.cpp otherarch/ttscpp/src/ttscpp.cpp otherarch/ttscpp/src/ttstokenizer.cpp otherarch/ttscpp/src/ttssampler.cpp otherarch/ttscpp/src/parler_model.cpp otherarch/ttscpp/src/dac_model.cpp otherarch/ttscpp/src/ttsutil.cpp otherarch/ttscpp/src/ttsargs.cpp otherarch/ttscpp/src/ttst5_encoder_model.cpp otherarch/ttscpp/src/phonemizer.cpp otherarch/ttscpp/src/tts_model.cpp otherarch/ttscpp/src/kokoro_model.cpp otherarch/ttscpp/src/dia_model.cpp otherarch/ttscpp/src/orpheus_model.cpp otherarch/ttscpp/src/snac_model.cpp otherarch/ttscpp/src/general_neural_audio_codec.cpp
@@ -747,15 +739,18 @@ music_default.o: otherarch/acestep/music_adapter.cpp
 
 # idiotic "for easier compilation"
 GPTTYPE_ADAPTER = gpttype_adapter.cpp model_adapter.h otherarch/otherarch.h include/llama.h otherarch/llama_v2.cpp otherarch/llama_v3.cpp otherarch/gptj_v1.cpp otherarch/gptj_v2.cpp otherarch/gptj_v3.cpp otherarch/gpt2_v1.cpp otherarch/gpt2_v2.cpp otherarch/gpt2_v3.cpp otherarch/rwkv_v2.cpp otherarch/rwkv_v3.cpp otherarch/neox_v2.cpp otherarch/neox_v3.cpp otherarch/mpt_v3.cpp
-gpttype_adapter_failsafe.o: $(GPTTYPE_ADAPTER)
-	$(CXX) $(CXXFLAGS) $(FAILSAFE_FLAGS) -c $< -o $@
-gpttype_adapter.o: $(GPTTYPE_ADAPTER)
+gpttype_adapter_default.o: $(GPTTYPE_ADAPTER)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
-gpttype_adapter_cublas.o: $(GPTTYPE_ADAPTER)
+
+kcpp_backend_failsafe.o: kcpp_backend.cpp kcpp_backend.h
+	$(CXX) $(CXXFLAGS) $(FAILSAFE_FLAGS) -c $< -o $@
+kcpp_backend_default.o: kcpp_backend.cpp kcpp_backend.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+kcpp_backend_cublas.o: kcpp_backend.cpp kcpp_backend.h
 	$(CXX) $(CXXFLAGS) $(CUBLAS_FLAGS) $(HIPFLAGS) -c $< -o $@
-gpttype_adapter_vulkan.o: $(GPTTYPE_ADAPTER)
+kcpp_backend_vulkan.o: kcpp_backend.cpp kcpp_backend.h
 	$(CXX) $(CXXFLAGS) $(VULKAN_FLAGS) -c $< -o $@
-gpttype_adapter_vulkan_noavx2.o: $(GPTTYPE_ADAPTER)
+kcpp_backend_vulkan_noavx2.o: kcpp_backend.cpp kcpp_backend.h
 	$(CXX) $(CXXFLAGS) $(FAILSAFE_FLAGS) $(VULKAN_FLAGS) -c $< -o $@
 
 clean:
@@ -768,13 +763,13 @@ clean:
 # useful tools
 main: tools/completion/main.cpp tools/completion/completion.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
-mainvk: tools/completion/main.cpp tools/completion/completion.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_vulkan.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
+mainvk: tools/completion/main.cpp tools/completion/completion.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
 	$(CXX) $(CXXFLAGS) -DGGML_USE_VULKAN $(filter-out %.h,$^) -o $@ $(LDFLAGS)
-fitparams: tools/fit-params/main.cpp tools/fit-params/fit-params.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_vulkan.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
+fitparams: tools/fit-params/main.cpp tools/fit-params/fit-params.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
 	$(CXX) $(CXXFLAGS) -DGGML_USE_VULKAN $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 sdmain: $(OBJS_SDCOMMON) $(OBJS_SDMAIN) build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
-whispermain: otherarch/whispercpp/main.cpp otherarch/whispercpp/whisper.cpp build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
+whispermain: otherarch/whispercpp/main.cpp otherarch/whispercpp/whisper.cpp kcpp_backend.o build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 ttsmain: tools/tts/tts.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
@@ -784,17 +779,17 @@ mtmd-cli: tools/mtmd/mtmd-cli.cpp tools/mtmd/clip.cpp common/debug.cpp common/ar
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 embedding: examples/embedding/embedding.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) src/llama-cparams.cpp build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
-embeddingvk: examples/embedding/embedding.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) src/llama-cparams.cpp build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_vulkan.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
+embeddingvk: examples/embedding/embedding.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) src/llama-cparams.cpp build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
 	$(CXX) $(CXXFLAGS) -DGGML_USE_VULKAN $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 ttscppmain: otherarch/ttscpp/cli/cli.cpp otherarch/ttscpp/cli/playback.cpp otherarch/ttscpp/cli/playback.h otherarch/ttscpp/cli/write_file.cpp otherarch/ttscpp/cli/write_file.h otherarch/ttscpp/cli/vad.cpp otherarch/ttscpp/cli/vad.h otherarch/ttscpp/src/ttscpp.cpp otherarch/ttscpp/src/ttstokenizer.cpp otherarch/ttscpp/src/ttssampler.cpp otherarch/ttscpp/src/parler_model.cpp otherarch/ttscpp/src/dac_model.cpp otherarch/ttscpp/src/ttsutil.cpp otherarch/ttscpp/src/ttsargs.cpp otherarch/ttscpp/src/ttst5_encoder_model.cpp otherarch/ttscpp/src/phonemizer.cpp otherarch/ttscpp/src/tts_model.cpp otherarch/ttscpp/src/kokoro_model.cpp otherarch/ttscpp/src/dia_model.cpp otherarch/ttscpp/src/orpheus_model.cpp otherarch/ttscpp/src/snac_model.cpp otherarch/ttscpp/src/general_neural_audio_codec.cpp ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 qwen3tts: otherarch/qwen3tts/q3ttsmain.cpp otherarch/qwen3tts/qwen3_tts.cpp otherarch/qwen3tts/text_tokenizer.cpp otherarch/qwen3tts/gguf_loader.cpp otherarch/qwen3tts/tts_transformer.cpp otherarch/qwen3tts/audio_tokenizer_decoder.cpp otherarch/qwen3tts/audio_tokenizer_encoder.cpp otherarch/qwen3tts/coreml_code_predictor_stub.cpp ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
-rpcserver: tools/rpc/rpc-server.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_vulkan.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
+rpcserver: tools/rpc/rpc-server.cpp common/arg.cpp common/preset.cpp $(COMMON_DOWNLOAD_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
 	$(CXX) $(CXXFLAGS) -DGGML_USE_VULKAN $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 llamaserver: $(LLAMASERVER_SRCS) $(LLAMASERVER_COMMON_SRCS) build-info.h ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_default.o ggml-repack.o $(OBJS_FULL) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LLAMASERVER_CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
-llamaservervk: $(LLAMASERVER_SRCS) $(LLAMASERVER_COMMON_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_vulkan.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
+llamaservervk: $(LLAMASERVER_SRCS) $(LLAMASERVER_COMMON_SRCS) build-info.h ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml-binops.o ggml-unops.o llama.o chat.o llama-model.o console.o clip_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o ggml-backend.o ggml-backend-meta.o ggml-backend-reg_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-repack.o $(OBJS_FULL) $(OBJS) lib/vulkan-1.lib
 	$(CXX) $(CXXFLAGS) $(LLAMASERVER_CXXFLAGS) -DGGML_USE_VULKAN $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
 ggml/src/ggml-vulkan-shaders.cpp: ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -895,17 +890,17 @@ else
 endif
 
 # common object files for all libraries
-KOBOLDCPP_COMMON_OBJS = expose.o chat.o ggml-binops.o ggml-unops.o ggml-backend.o ggml-backend-meta.o ggml-repack.o llama.o llama-model.o embeddings_default.o music_default.o tts_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o $(OBJS) $(OBJS_SDTYPE)
+KOBOLDCPP_COMMON_OBJS = gpttype_adapter_default.o whispercpp_default.o clip_default.o expose.o chat.o ggml-binops.o ggml-unops.o ggml-backend.o ggml-backend-meta.o ggml-repack.o llama.o llama-model.o embeddings_default.o music_default.o tts_default.o mtmd.o mtmd-helper.o mtmd-helper-gen.o mtmd-image.o $(OBJS) $(OBJS_SDTYPE)
 
 #generated libraries
-koboldcpp_default: ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3.o ggml_v2.o ggml_v1.o gpttype_adapter.o whispercpp_default.o clip_default.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
+koboldcpp_default: ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3.o ggml_v2.o ggml_v1.o kcpp_backend_default.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
 	$(DEFAULT_BUILD)
 
-koboldcpp_macos_failsafe: ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3.o ggml_v2.o ggml_v1.o gpttype_adapter.o whispercpp_default.o clip_default.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
+koboldcpp_macos_failsafe: ggml.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3.o ggml_v2.o ggml_v1.o kcpp_backend_default.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
 	$(DEFAULT_BUILD)
 
 ifdef FAILSAFE_BUILD
-koboldcpp_failsafe: ggml_v4_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o gpttype_adapter_failsafe.o whispercpp_default.o clip_default.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FAILSAFE)
+koboldcpp_failsafe: ggml_v4_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o kcpp_backend_failsafe.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FAILSAFE)
 	$(FAILSAFE_BUILD)
 else
 koboldcpp_failsafe:
@@ -913,7 +908,7 @@ koboldcpp_failsafe:
 endif
 
 ifdef NOAVX2_BUILD
-koboldcpp_noavx2: ggml_v4_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o gpttype_adapter_failsafe.o whispercpp_default.o clip_default.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_SIMPLE)
+koboldcpp_noavx2: ggml_v4_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o kcpp_backend_failsafe.o ggml-backend-reg_default.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_SIMPLE)
 	$(NOAVX2_BUILD)
 else
 koboldcpp_noavx2:
@@ -921,7 +916,7 @@ koboldcpp_noavx2:
 endif
 
 ifdef CUBLAS_BUILD
-koboldcpp_cublas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o gpttype_adapter_cublas.o whispercpp_cublas.o clip_cublas.o ggml-backend-reg_cublas.o $(CUBLAS_OBJS) $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
+koboldcpp_cublas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o kcpp_backend_cublas.o ggml-backend-reg_cublas.o $(CUBLAS_OBJS) $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
 	$(CUBLAS_BUILD)
 else
 koboldcpp_cublas:
@@ -929,7 +924,7 @@ koboldcpp_cublas:
 endif
 
 ifdef HIPBLAS_BUILD
-koboldcpp_hipblas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o gpttype_adapter_cublas.o whispercpp_cublas.o clip_cublas.o ggml-backend-reg_cublas.o $(HIP_OBJS) $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
+koboldcpp_hipblas: ggml_v4_cublas.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3_cublas.o ggml_v2_cublas.o ggml_v1.o kcpp_backend_cublas.o ggml-backend-reg_cublas.o $(HIP_OBJS) $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
 	$(HIPBLAS_BUILD)
 else
 koboldcpp_hipblas:
@@ -937,12 +932,12 @@ koboldcpp_hipblas:
 endif
 
 ifdef VULKAN_BUILD
-koboldcpp_vulkan: ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3.o ggml_v2.o ggml_v1.o gpttype_adapter_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o whispercpp_vulkan.o clip_vulkan.o ggml-backend-reg_vulkan.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
+koboldcpp_vulkan: ggml_v4_vulkan.o ggml-cpu.o ggml-ops.o ggml-vec.o ggml_v3.o ggml_v2.o ggml_v1.o kcpp_backend_vulkan.o ggml-vulkan.o ggml-vulkan-shaders.o ggml-backend-reg_vulkan.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_FULL)
 	$(VULKAN_BUILD)
 ifdef NOAVX2_BUILD
-koboldcpp_vulkan_noavx2: ggml_v4_vulkan_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o gpttype_adapter_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o whispercpp_vulkan.o clip_vulkan.o ggml-backend-reg_vulkan.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_SIMPLE)
+koboldcpp_vulkan_noavx2: ggml_v4_vulkan_noavx2.o ggml-cpu_v4_noavx2.o ggml-ops-noavx2.o ggml-vec-noavx2.o ggml_v3_noavx2.o ggml_v2_noavx2.o ggml_v1_failsafe.o kcpp_backend_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o ggml-backend-reg_vulkan.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_SIMPLE)
 	$(VULKAN_BUILD)
-koboldcpp_vulkan_failsafe: ggml_v4_vulkan_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o gpttype_adapter_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o whispercpp_vulkan.o clip_vulkan.o ggml-backend-reg_vulkan.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_SIMPLER)
+koboldcpp_vulkan_failsafe: ggml_v4_vulkan_failsafe.o ggml-cpu_v4_failsafe.o ggml-ops-failsafe.o ggml-vec-failsafe.o ggml_v3_failsafe.o ggml_v2_failsafe.o ggml_v1_failsafe.o kcpp_backend_vulkan_noavx2.o ggml-vulkan-noext.o ggml-vulkan-shaders-noext.o ggml-backend-reg_vulkan.o $(KOBOLDCPP_COMMON_OBJS) $(OBJS_SIMPLER)
 	$(VULKAN_BUILD)
 else
 koboldcpp_vulkan_noavx2:

--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -33,10 +33,7 @@
 
 #include "utils.h"
 #include "llmutils.h"
-
-#ifdef GGML_USE_CUDA
-#  include "ggml-cuda.h"
-#endif
+#include "kcpp_backend.h"
 
 #include "llama_v2.cpp"
 #include "llama_v3.cpp"
@@ -68,11 +65,6 @@
 #include "llama-model.h"
 #include "llama-vocab.h"
 #include "nlohmann/json.hpp"
-
-#if defined(GGML_USE_HIP)
-// for rocblas_initialize()
-#include "rocblas/rocblas.h"
-#endif
 
 //const
 const int extra_context_handle_fragmentation = 128;
@@ -202,14 +194,6 @@ extern bool kcpp_pipeline_parallelism;
 extern bool OldBPETokenizerMode;
 extern int kcpp_extra_swa_padding;
 extern int kcpp_active_swa_size;
-
-inline int kcpp_cpu_has_blas(void) {
-#if defined(GGML_USE_BLAS) || defined(GGML_USE_CUDA) || defined(GGML_USE_VULKAN) || defined(GGML_USE_SYCL)
-    return 1;
-#else
-    return 0;
-#endif
-}
 
 inline bool IsNanCheck(float f)
 {
@@ -539,6 +523,18 @@ std::string get_fitted_params_str(const llama_model_params & mparams, const llam
     return out.str();
 }
 
+static bool has_tensor_split(const float* ratios, int num_ratios, ggml_backend_t backend = nullptr)
+{
+    if(kcpp_backend_check(KCPP_BACKENDS_TENSOR_SPLIT, backend)) {
+        for (int i = 0; i < tensor_split_max; ++i) {
+            if (ratios[i] != 0.0f) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 static size_t estimate_draft_autofit_tax_mb(
     const std::string & main_model_filename,
     const std::string & spec_model_filename,
@@ -577,19 +573,9 @@ static size_t estimate_draft_autofit_tax_mb(
     draft_ctx_params.swa_full = base_ctx_params.swa_full;
     draft_ctx_params.n_rs_seq = 0;
 
-    #if defined(GGML_USE_CUDA) || defined(GGML_USE_VULKAN)
-    bool ts_all_zero = true;
-    for (int i = 0; i < tensor_split_max; ++i) {
-        if (draft_gpusplit[i] != 0.0f) {
-            ts_all_zero = false;
-            break;
-        }
-    }
-    if(!ts_all_zero)
-    {
+    if(has_tensor_split(draft_gpusplit, tensor_split_max)) {
         draft_model_params.tensor_split = draft_gpusplit;
     }
-    #endif
 
     const char * estimate_model_path = has_draft_model ? spec_model_filename.c_str() : main_model_filename.c_str();
     bool measure_model_bytes = true;
@@ -988,20 +974,11 @@ static void speculative_decoding_setup(std::string spec_model_filename, llama_co
     draft_model_params.main_gpu = base_model_params.main_gpu;
     draft_model_params.split_mode = llama_split_mode::LLAMA_SPLIT_MODE_LAYER;
     draft_ctx_params.kv_unified = base_ctx_params.kv_unified;
-    #if defined(GGML_USE_CUDA) || defined(GGML_USE_VULKAN)
-    bool ts_all_zero = true;
-    for (int i = 0; i < tensor_split_max; ++i) {
-        if (draft_gpusplit[i] != 0.0f) {
-            ts_all_zero = false;
-            break;
-        }
-    }
-    if(!ts_all_zero)
-    {
+
+    if(has_tensor_split(draft_gpusplit, tensor_split_max)) {
         printf("\nApplying Draft GPU Split...\n");
         draft_model_params.tensor_split = draft_gpusplit;
     }
-    #endif
     draft_ctx_params.n_batch = base_ctx_params.n_batch;
     draft_ctx_params.n_ubatch = base_ctx_params.n_ubatch;
     draft_ctx_params.n_threads = base_ctx_params.n_threads;
@@ -3002,20 +2979,20 @@ static void connect_rpc_servers(const std::string & servers) {
 
 mtmd_context_params init_mtmd_ctx_params(bool mmproj_cpu, bool dryrun)
 {
-    #if defined(GGML_USE_METAL)
-    if(file_format_meta.model_architecture == llm_arch::LLM_ARCH_QWEN2VL || file_format_meta.model_architecture == llm_arch::LLM_ARCH_GEMMA3)
-    {
-        mmproj_cpu = true;
-        if(!dryrun)
+    if(kcpp_backend_check("mtl")) {
+        if(file_format_meta.model_architecture == llm_arch::LLM_ARCH_QWEN2VL || file_format_meta.model_architecture == llm_arch::LLM_ARCH_GEMMA3)
         {
-            printf("MTMD will use CPU for this model!\n");
+            mmproj_cpu = true;
+            if(!dryrun)
+            {
+                printf("MTMD will use CPU for this model!\n");
+            }
         }
     }
-    #endif
     llama_flash_attn_type mtmd_fa = (kcpp_data->flash_attn?LLAMA_FLASH_ATTN_TYPE_ENABLED:LLAMA_FLASH_ATTN_TYPE_DISABLED);
-    #if defined(GGML_USE_CUDA)
-    mtmd_fa = LLAMA_FLASH_ATTN_TYPE_DISABLED; //kcpp: disabled in 1.102.2 as some headsizes break on turing
-    #endif
+    if(kcpp_backend_check("cuda")) {
+        mtmd_fa = LLAMA_FLASH_ATTN_TYPE_DISABLED; //kcpp: disabled in 1.102.2 as some headsizes break on turing
+    }
     if(mmproj_cpu)
     {
         if(!dryrun)
@@ -3156,17 +3133,14 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
     int kcpp_parseinfo_maindevice = inputs.kcpp_main_gpu<=0?0:inputs.kcpp_main_gpu;
 
     printf("System Info: %s\n", kcpp_print_system_info());
-    #if defined(GGML_USE_CUDA)
     if(file_format!=FileFormat::GGUF_GENERIC)
     {
         if(ggml_v3_cpu_has_gpublas() && kcpp_parseinfo_maindevice>0)
         {
-            printf("CUBLAS v3: Set main device to %d\n",kcpp_parseinfo_maindevice);
-            ggml_v3_cuda_set_main_device(kcpp_parseinfo_maindevice);
+            kcpp_backend_cuda_ggmlv3_set_main_device(kcpp_parseinfo_maindevice);
         }
     }
 
-    #endif
     SetQuantsUnshuffled(false);
     if(file_format == FileFormat::GGML || file_format == FileFormat::GGHF || file_format == FileFormat::GGJT || file_format == FileFormat::GGJT_2)
     {
@@ -3230,20 +3204,10 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
         llama_ctx_params.rope_freq_scale = rope_freq_scale;
         llama_ctx_params.n_batch = kcpp_data->n_batch;
 
-        #if defined(GGML_USE_CUDA) || defined(GGML_USE_VULKAN)
-        bool ts_all_zero = true;
-        for (int i = 0; i < tensor_split_max; ++i) {
-            if (inputs.tensor_split[i] != 0.0f) {
-                ts_all_zero = false;
-                break;
-            }
-        }
-        if(!ts_all_zero)
-        {
+        if(has_tensor_split(inputs.tensor_split, tensor_split_max)) {
             printf("\nApplying Tensor Split...\n");
             llama_ctx_params.tensor_split = inputs.tensor_split;
         }
-        #endif
 
         llama_ctx_v3 = llama_v3_init_from_file(kcpp_data->model_filename.c_str(), llama_ctx_params);
 
@@ -3335,11 +3299,11 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
             printf("Main GPU device: Try set to %d\n",kcpp_parseinfo_maindevice);
         }
 
-        #if defined(GGML_USE_CUDA)
-        printf("CUDA MMQ: %s\n",(inputs.use_mmq?"True":"False"));
-        printf("---\nInitializing CUDA/HIP, please wait, the following step may take a few minutes (only for first launch)...\n---\n");
-        ggml_cuda_set_mul_mat_q(inputs.use_mmq);
-        #endif
+        if(kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
+            printf("CUDA MMQ: %s\n",(inputs.use_mmq?"True":"False"));
+            printf("---\nInitializing CUDA/HIP, please wait, the following step may take a few minutes (only for first launch)...\n---\n");
+            kcpp_backend_cuda_set_mul_mat_q(inputs.use_mmq);
+        }
 
         model_params.main_gpu = kcpp_parseinfo_maindevice;
         model_params.split_mode = (inputs.splitmode>0?((llama_split_mode)(inputs.splitmode)):llama_split_mode::LLAMA_SPLIT_MODE_LAYER);
@@ -3353,20 +3317,10 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
         llama_ctx_params.n_threads = kcpp_data->n_threads;
         llama_ctx_params.n_threads_batch = kcpp_data->n_blasthreads;
 
-        #if defined(GGML_USE_CUDA) || defined(GGML_USE_VULKAN)
-        bool ts_all_zero = true;
-        for (int i = 0; i < tensor_split_max; ++i) {
-            if (inputs.tensor_split[i] != 0.0f) {
-                ts_all_zero = false;
-                break;
-            }
-        }
-        if(!ts_all_zero)
-        {
+        if(has_tensor_split(inputs.tensor_split, tensor_split_max)) {
             printf("\nApplying Tensor Split...\n");
             model_params.tensor_split = inputs.tensor_split;
         }
-        #endif
 
         //compat for old falcon
         if(file_format_meta.fileversion==1)
@@ -3492,9 +3446,7 @@ ModelLoadResult gpttype_load_model(const load_model_inputs inputs, FileFormat in
         std::vector<size_t> fit_params_target = std::vector<size_t>(llama_max_devices(),1024*1024*1024);
         if(inputs.autofit)
         {
-            #if defined(GGML_USE_HIP)
-            rocblas_initialize();
-            #endif // defined(GGML_USE_HIP)
+            kcpp_backend_hip_initialize();
 
             size_t totalmmprojtax = 0;
             if(mmproj_filename != "" && file_format==FileFormat::GGUF_GENERIC && !inputs.mmproj_cpu)
@@ -5315,11 +5267,10 @@ int GetThreadsToUse(bool blasmode)
 {
     if (blasmode)
     {
-        #if defined(GGML_USE_CUDA) || defined(GGML_USE_VULKAN)
+        if(kcpp_backend_check(KCPP_BACKENDS_USE_CUDA "|vulkan"))
             return kcpp_data->n_blasthreads;
-        #else
+        else
             return std::min(kcpp_data->n_blasthreads, 4);
-        #endif
     }
     return kcpp_data->n_threads;
 }
@@ -6469,7 +6420,7 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
         }
     }
 
-    bool blasmode = (embd_inp.size() >= 32 && kcpp_cpu_has_blas() && kcpp_data->n_batch>=32);
+    bool blasmode = (embd_inp.size() >= 32 && kcpp_backend_check(KCPP_BACKENDS_BLAS) && kcpp_data->n_batch>=32);
 
     if(current_context_tokens.size()>n_past)
     {

--- a/kcpp_backend.cpp
+++ b/kcpp_backend.cpp
@@ -7,6 +7,7 @@
 
 #ifdef GGML_USE_CUDA
 #  include "ggml-cuda.h"
+#  include "ggml_v2-cuda.h"
 #  include "ggml_v3-cuda.h"
 #endif
 
@@ -102,6 +103,13 @@ int kcpp_backend_check(const char* name, ggml_backend_t backend)
     }
     std::string lo_dev_name = to_lowercase(ggml_backend_dev_name(dev));
     return has_any_prefix(lo_dev_name, name, '|');
+}
+
+void kcpp_backend_cuda_ggmlv2_transform_tensor(ggml_v2_tensor * tensor)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v2_cuda_transform_tensor(tensor);
+    #endif
 }
 
 void kcpp_backend_cuda_ggmlv3_set_main_device(int device)

--- a/kcpp_backend.cpp
+++ b/kcpp_backend.cpp
@@ -16,6 +16,10 @@
 #  include "rocblas/rocblas.h"
 #endif
 
+#if defined(GGML_USE_METAL)
+#  include "ggml-metal.h"
+#endif
+
 static std::string to_lowercase(const char* ptr) {
     std::string s = (ptr == nullptr) ? "" : ptr;
     std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
@@ -48,6 +52,19 @@ static ggml_backend_dev_t get_ggml_main_device(void)
     dev = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_IGPU);
     dev = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
     return dev;
+}
+
+ggml_backend_dev_t kcpp_backend_get_device(int index)
+{
+    if (index < 0) {
+        if (index == -1) {
+            return get_ggml_main_device();
+        } else {
+           return ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+        }
+    } else {
+        return ggml_backend_dev_get((size_t)index);
+    }
 }
 
 // this is similar to sd_backend_is, except:
@@ -103,6 +120,15 @@ int kcpp_backend_check(const char* name, ggml_backend_t backend)
     }
     std::string lo_dev_name = to_lowercase(ggml_backend_dev_name(dev));
     return has_any_prefix(lo_dev_name, name, '|');
+}
+
+bool kcpp_backend_metal_supports_family(ggml_backend_t backend, int family)
+{
+    #if defined(GGML_USE_METAL)
+    return ggml_backend_metal_supports_family(backend, family);
+    #else
+    return false;
+    #endif
 }
 
 void kcpp_backend_cuda_ggmlv2_transform_tensor(ggml_v2_tensor * tensor)

--- a/kcpp_backend.cpp
+++ b/kcpp_backend.cpp
@@ -119,10 +119,66 @@ void kcpp_backend_cuda_ggmlv3_set_main_device(int device)
     #endif
 }
 
+void kcpp_backend_cuda_ggmlv3_set_tensor_split(const float * tensor_split)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_set_tensor_split(tensor_split);
+    #endif
+}
+
 void kcpp_backend_cuda_ggmlv3_transform_tensor(void * data, struct ggml_v3_tensor * tensor)
 {
     #if defined(GGML_USE_CUDA)
     ggml_v3_cuda_transform_tensor(tensor->data, tensor);
+    #endif
+}
+
+void kcpp_backend_cuda_ggmlv3_free_data(struct ggml_v3_tensor * tensor)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_free_data(tensor);
+    #endif
+}
+
+void kcpp_backend_cuda_ggmlv3_free_scratch(void)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_free_scratch();
+    #endif
+}
+
+void kcpp_backend_cuda_ggmlv3_assign_buffers(struct ggml_v3_tensor * tensor)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_assign_buffers(tensor);
+    #endif
+}
+
+void kcpp_backend_cuda_ggmlv3_assign_buffers_force_inplace(struct ggml_v3_tensor * tensor)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_assign_buffers_force_inplace(tensor);
+    #endif
+}
+
+void kcpp_backend_cuda_ggmlv3_assign_buffers_no_scratch(struct ggml_v3_tensor * tensor)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_assign_buffers_no_scratch(tensor);
+    #endif
+}
+
+void kcpp_backend_cuda_ggmlv3_set_mul_mat_q(bool mul_mat_q)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_set_mul_mat_q(mul_mat_q);
+    #endif
+}
+
+void kcpp_backend_cuda_ggmlv3_set_scratch_size(size_t scratch_size)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_set_scratch_size(scratch_size);
     #endif
 }
 

--- a/kcpp_backend.cpp
+++ b/kcpp_backend.cpp
@@ -1,0 +1,127 @@
+#include "kcpp_backend.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <string>
+
+#ifdef GGML_USE_CUDA
+#  include "ggml-cuda.h"
+#  include "ggml_v3-cuda.h"
+#endif
+
+#if defined(GGML_USE_HIP)
+// for rocblas_initialize()
+#  include "rocblas/rocblas.h"
+#endif
+
+static std::string to_lowercase(const char* ptr) {
+    std::string s = (ptr == nullptr) ? "" : ptr;
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+        return std::tolower(c);
+    });
+    return s;
+}
+
+static bool has_any_prefix(const std::string& str, const std::string& prefixes, char delimiter) {
+    size_t start = 0;
+    size_t end = prefixes.find(delimiter);
+    while (start != std::string::npos) {
+        std::string prefix = prefixes.substr(start, end - start);
+        if (str.rfind(prefix, 0) == 0) {
+            return true;
+        }
+        if (end == std::string::npos) {
+            break;
+        }
+        start = end + 1;
+        end = prefixes.find(delimiter, start);
+    }
+    return false;
+}
+
+static ggml_backend_dev_t get_ggml_main_device(void)
+{
+    // similar to ggml_backend_init_best
+    ggml_backend_dev_t dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_GPU);
+    dev = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_IGPU);
+    dev = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    return dev;
+}
+
+// this is similar to sd_backend_is, except:
+// - if no backend is provided, checks the first ggml device (should be equivalent to a compile-time check)
+// - tests a |-separated list of device names
+int kcpp_backend_check(const char* name, ggml_backend_t backend)
+{
+    std::string loname = to_lowercase(name);
+    if (loname == "") {
+        return false;
+    }
+
+    ggml_backend_dev_t dev = nullptr;
+    if (backend == nullptr) {
+        // note we are assuming there is only one gpu backend type
+
+        const char* KCPP_BACKEND_DYNAMIC = std::getenv("KCPP_BACKEND_DYNAMIC");
+        if (KCPP_BACKEND_DYNAMIC == nullptr || std::string(KCPP_BACKEND_DYNAMIC) == "0") {
+
+            #if defined(GGML_USE_VULKAN)
+            const char * devname = "vulkan";
+
+            #elif defined(GGML_USE_METAL)
+            const char * devname = "mtl";
+
+            #elif defined(GGML_USE_HIP)
+            const char * devname = "rocm";
+
+            #elif defined(GGML_USE_CUDA)
+            const char * devname = "cuda";
+
+            #elif defined(GGML_USE_SYCL)
+            const char * devname = "sycl";
+
+            #elif defined(GGML_USE_BLAS)
+            const char * devname = "blas";
+
+            #else
+            const char * devname = nullptr;
+            #endif
+
+            if (devname != nullptr) {
+                return has_any_prefix(devname, name, '|');
+            }
+        }
+
+        dev = get_ggml_main_device();
+    } else {
+        dev = ggml_backend_get_device(backend);
+    }
+    if (!dev) {
+        return false;
+    }
+    std::string lo_dev_name = to_lowercase(ggml_backend_dev_name(dev));
+    return has_any_prefix(lo_dev_name, name, '|');
+}
+
+void kcpp_backend_cuda_ggmlv3_set_main_device(int device)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_set_main_device(device);
+    #endif
+}
+
+void kcpp_backend_cuda_set_mul_mat_q(int use_mmq)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_cuda_set_mul_mat_q(use_mmq);
+    #endif
+}
+
+void kcpp_backend_hip_initialize()
+{
+    #if defined(GGML_USE_HIP)
+    rocblas_initialize();
+    #endif
+}
+

--- a/kcpp_backend.cpp
+++ b/kcpp_backend.cpp
@@ -111,6 +111,13 @@ void kcpp_backend_cuda_ggmlv3_set_main_device(int device)
     #endif
 }
 
+void kcpp_backend_cuda_ggmlv3_transform_tensor(void * data, struct ggml_v3_tensor * tensor)
+{
+    #if defined(GGML_USE_CUDA)
+    ggml_v3_cuda_transform_tensor(tensor->data, tensor);
+    #endif
+}
+
 void kcpp_backend_cuda_set_mul_mat_q(int use_mmq)
 {
     #if defined(GGML_USE_CUDA)

--- a/kcpp_backend.h
+++ b/kcpp_backend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ggml-backend.h"
+#include "ggml_v2.h"
 #include "ggml_v3.h"
 
 // backends with GGML_USE_CUDA
@@ -17,6 +18,8 @@ int kcpp_backend_check(const char* name_list, ggml_backend_t backend = nullptr);
 
 
 // per-backend aux functions
+
+void kcpp_backend_cuda_ggmlv2_transform_tensor(ggml_v2_tensor * tensor);
 
 void kcpp_backend_cuda_ggmlv3_set_main_device(int device);
 void kcpp_backend_cuda_ggmlv3_transform_tensor(void * data, struct ggml_v3_tensor * tensor);

--- a/kcpp_backend.h
+++ b/kcpp_backend.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "ggml-backend.h"
+
+// backends with GGML_USE_CUDA
+#define KCPP_BACKENDS_USE_CUDA "cuda|rocm"
+
+// backends that support tensor split
+#define KCPP_BACKENDS_TENSOR_SPLIT "cuda|rocm|vulkan"
+
+// backends that support blas
+#define KCPP_BACKENDS_BLAS "blas|cuda|rocm|vulkan|sycl"
+
+// checks if the provided backend (or the first one) matches a |-separated name list
+int kcpp_backend_check(const char* name_list, ggml_backend_t backend = nullptr);
+
+
+// per-backend aux functions
+
+void kcpp_backend_cuda_ggmlv3_set_main_device(int device);
+
+void kcpp_backend_cuda_set_mul_mat_q(int use_mmq);
+
+void kcpp_backend_hip_initialize();
+

--- a/kcpp_backend.h
+++ b/kcpp_backend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ggml-backend.h"
+#include "ggml_v3.h"
 
 // backends with GGML_USE_CUDA
 #define KCPP_BACKENDS_USE_CUDA "cuda|rocm"
@@ -18,6 +19,7 @@ int kcpp_backend_check(const char* name_list, ggml_backend_t backend = nullptr);
 // per-backend aux functions
 
 void kcpp_backend_cuda_ggmlv3_set_main_device(int device);
+void kcpp_backend_cuda_ggmlv3_transform_tensor(void * data, struct ggml_v3_tensor * tensor);
 
 void kcpp_backend_cuda_set_mul_mat_q(int use_mmq);
 

--- a/kcpp_backend.h
+++ b/kcpp_backend.h
@@ -21,7 +21,15 @@ int kcpp_backend_check(const char* name_list, ggml_backend_t backend = nullptr);
 
 void kcpp_backend_cuda_ggmlv2_transform_tensor(ggml_v2_tensor * tensor);
 
+void kcpp_backend_cuda_ggmlv3_assign_buffers(struct ggml_v3_tensor * tensor);
+void kcpp_backend_cuda_ggmlv3_assign_buffers_force_inplace(struct ggml_v3_tensor * tensor);
+void kcpp_backend_cuda_ggmlv3_assign_buffers_no_scratch(struct ggml_v3_tensor * tensor);
+void kcpp_backend_cuda_ggmlv3_free_data(struct ggml_v3_tensor * tensor);
+void kcpp_backend_cuda_ggmlv3_free_scratch(void);
 void kcpp_backend_cuda_ggmlv3_set_main_device(int device);
+void kcpp_backend_cuda_ggmlv3_set_mul_mat_q(bool mul_mat_q);
+void kcpp_backend_cuda_ggmlv3_set_scratch_size(size_t scratch_size);
+void kcpp_backend_cuda_ggmlv3_set_tensor_split(const float * tensor_split);
 void kcpp_backend_cuda_ggmlv3_transform_tensor(void * data, struct ggml_v3_tensor * tensor);
 
 void kcpp_backend_cuda_set_mul_mat_q(int use_mmq);

--- a/kcpp_backend.h
+++ b/kcpp_backend.h
@@ -16,6 +16,7 @@
 // checks if the provided backend (or the first one) matches a |-separated name list
 int kcpp_backend_check(const char* name_list, ggml_backend_t backend = nullptr);
 
+ggml_backend_dev_t kcpp_backend_get_device(int index);
 
 // per-backend aux functions
 
@@ -35,4 +36,6 @@ void kcpp_backend_cuda_ggmlv3_transform_tensor(void * data, struct ggml_v3_tenso
 void kcpp_backend_cuda_set_mul_mat_q(int use_mmq);
 
 void kcpp_backend_hip_initialize();
+
+bool kcpp_backend_metal_supports_family(ggml_backend_t backend, int family);
 

--- a/otherarch/gpt2_v3.cpp
+++ b/otherarch/gpt2_v3.cpp
@@ -15,14 +15,7 @@
 #include <algorithm>
 
 #include "model_adapter.h"
-
-#ifdef GGML_USE_CUDA
-#include "ggml_v3-cuda.h"
-#endif
-#if defined(GGML_USE_CLBLAST)
-#include "ggml_v3-opencl.h"
-#endif
-
+#include "kcpp_backend.h"
 
 // load the model's weights from a file
 ModelLoadResult gpt2_model_load(const std::string & fname, gpt2_model & model, gpt_vocab & vocab, FileFormat file_format, int gpulayers) {
@@ -358,42 +351,27 @@ ModelLoadResult gpt2_model_load(const std::string & fname, gpt2_model & model, g
     fin.close();
 
     //gpu offload
-    #if defined(GGML_USE_CLBLAST) || defined(GGML_USE_CUDA)
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
     if(gpulayers>0)
     {
         const auto & hparams = model.hparams;
         size_t vram_total = 0;
         const int n_gpu = std::min(gpulayers, int(hparams.n_layer));
-        #if defined(GGML_USE_CLBLAST)
-        fprintf(stderr, "%s: [opencl] offloading %d layers to GPU\n", __func__, n_gpu);
-        #else
         fprintf(stderr, "%s: [CUDA] offloading %d layers to GPU\n", __func__, n_gpu);
-        #endif
         for (int i = 0; i < n_gpu; ++i) {
             const auto & layer = model.layers[i];
             layer.c_attn_attn_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_attn_proj_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_mlp_fc_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_mlp_proj_w->backend = GGML_V3_BACKEND_GPU;
-            #if defined(GGML_USE_CLBLAST)
-            ggml_v3_cl_transform_tensor(layer.c_attn_attn_w->data,layer.c_attn_attn_w); vram_total += ggml_v3_nbytes(layer.c_attn_attn_w);
-            ggml_v3_cl_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
-            ggml_v3_cl_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
-            ggml_v3_cl_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
-            #else
-            ggml_v3_cuda_transform_tensor(layer.c_attn_attn_w->data,layer.c_attn_attn_w); vram_total += ggml_v3_nbytes(layer.c_attn_attn_w);
-            ggml_v3_cuda_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
-            ggml_v3_cuda_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
-            ggml_v3_cuda_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
-            #endif
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_attn_w->data,layer.c_attn_attn_w); vram_total += ggml_v3_nbytes(layer.c_attn_attn_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
         }
-        #if defined(GGML_USE_CLBLAST)
-            fprintf(stderr, "%s: [opencl] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #else
             fprintf(stderr, "%s: [CUDA] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #endif
     }
-    #endif
+    }
 
     return ModelLoadResult::SUCCESS;
 }

--- a/otherarch/gptj_v3.cpp
+++ b/otherarch/gptj_v3.cpp
@@ -15,13 +15,7 @@
 #include <algorithm>
 
 #include "model_adapter.h"
-
-#ifdef GGML_USE_CUDA
-#include "ggml_v3-cuda.h"
-#endif
-#if defined(GGML_USE_CLBLAST)
-#include "ggml_v3-opencl.h"
-#endif
+#include "kcpp_backend.h"
 
 // load the model's weights from a file
 ModelLoadResult gptj_model_load(const std::string & fname, gptj_model & model, gpt_vocab & vocab, int gpulayers) {
@@ -347,17 +341,13 @@ ModelLoadResult gptj_model_load(const std::string & fname, gptj_model & model, g
     fin.close();
 
     //gpu offload
-    #if defined(GGML_USE_CLBLAST) || defined(GGML_USE_CUDA)
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
     if(gpulayers>0)
     {
         const auto & hparams = model.hparams;
         size_t vram_total = 0;
         const int n_gpu = std::min(gpulayers, int(hparams.n_layer));
-        #if defined(GGML_USE_CLBLAST)
-        fprintf(stderr, "%s: [opencl] offloading %d layers to GPU\n", __func__, n_gpu);
-        #else
         fprintf(stderr, "%s: [CUDA] offloading %d layers to GPU\n", __func__, n_gpu);
-        #endif
         for (int i = 0; i < n_gpu; ++i) {
             const auto & layer = model.layers[i];
             layer.c_attn_q_proj_w->backend = GGML_V3_BACKEND_GPU;
@@ -366,29 +356,16 @@ ModelLoadResult gptj_model_load(const std::string & fname, gptj_model & model, g
             layer.c_attn_proj_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_mlp_fc_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_mlp_proj_w->backend = GGML_V3_BACKEND_GPU;
-            #if defined(GGML_USE_CLBLAST)
-            ggml_v3_cl_transform_tensor(layer.c_attn_q_proj_w->data,layer.c_attn_q_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_q_proj_w);
-            ggml_v3_cl_transform_tensor(layer.c_attn_k_proj_w->data,layer.c_attn_k_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_k_proj_w);
-            ggml_v3_cl_transform_tensor(layer.c_attn_v_proj_w->data,layer.c_attn_v_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_v_proj_w);
-            ggml_v3_cl_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
-            ggml_v3_cl_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
-            ggml_v3_cl_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
-            #else
-            ggml_v3_cuda_transform_tensor(layer.c_attn_q_proj_w->data,layer.c_attn_q_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_q_proj_w);
-            ggml_v3_cuda_transform_tensor(layer.c_attn_k_proj_w->data,layer.c_attn_k_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_k_proj_w);
-            ggml_v3_cuda_transform_tensor(layer.c_attn_v_proj_w->data,layer.c_attn_v_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_v_proj_w);
-            ggml_v3_cuda_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
-            ggml_v3_cuda_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
-            ggml_v3_cuda_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
-            #endif
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_q_proj_w->data,layer.c_attn_q_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_q_proj_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_k_proj_w->data,layer.c_attn_k_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_k_proj_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_v_proj_w->data,layer.c_attn_v_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_v_proj_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
         }
-        #if defined(GGML_USE_CLBLAST)
-            fprintf(stderr, "%s: [opencl] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #else
-            fprintf(stderr, "%s: [CUDA] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #endif
+        fprintf(stderr, "%s: [CUDA] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
     }
-    #endif
+    }
 
     return ModelLoadResult::SUCCESS;
 }

--- a/otherarch/llama_v2.cpp
+++ b/otherarch/llama_v2.cpp
@@ -10,13 +10,7 @@
 
 #include "ggml_v2.h"
 
-#ifdef GGML_USE_CUDA
-#include "ggml_v2-cuda.h"
-#endif
-#if defined(GGML_USE_CLBLAST)
-#include "ggml_v2-opencl.h"
-#endif
-
+#include "kcpp_backend.h"
 
 #include <array>
 #include <ctime>
@@ -1068,7 +1062,7 @@ static void llama_v2_model_load_internal(
     ml->load_all_data(progress_callback, progress_callback_user_data, use_mlock ? &lctx.model.mlock_mmap : NULL);
 
     model.mapping = std::move(ml->mapping);
-#if defined(GGML_USE_CUDA)
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA))
     {
         const int n_gpu = std::min(n_gpu_layers, int(hparams.n_layer));
         if(GetQuantsUnshuffled())
@@ -1081,17 +1075,17 @@ static void llama_v2_model_load_internal(
         for (int i = 0; i < n_gpu; ++i) {
             const auto & layer = model.layers[i];
 
-            ggml_v2_cuda_transform_tensor(layer.wq); vram_total += ggml_v2_nbytes(layer.wq);
-            ggml_v2_cuda_transform_tensor(layer.wk); vram_total += ggml_v2_nbytes(layer.wk);
-            ggml_v2_cuda_transform_tensor(layer.wv); vram_total += ggml_v2_nbytes(layer.wv);
-            ggml_v2_cuda_transform_tensor(layer.wo); vram_total += ggml_v2_nbytes(layer.wo);
-            ggml_v2_cuda_transform_tensor(layer.w1); vram_total += ggml_v2_nbytes(layer.w1);
-            ggml_v2_cuda_transform_tensor(layer.w2); vram_total += ggml_v2_nbytes(layer.w2);
-            ggml_v2_cuda_transform_tensor(layer.w3); vram_total += ggml_v2_nbytes(layer.w3);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(layer.wq); vram_total += ggml_v2_nbytes(layer.wq);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(layer.wk); vram_total += ggml_v2_nbytes(layer.wk);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(layer.wv); vram_total += ggml_v2_nbytes(layer.wv);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(layer.wo); vram_total += ggml_v2_nbytes(layer.wo);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(layer.w1); vram_total += ggml_v2_nbytes(layer.w1);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(layer.w2); vram_total += ggml_v2_nbytes(layer.w2);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(layer.w3); vram_total += ggml_v2_nbytes(layer.w3);
         }
         if (n_gpu_layers > (int) hparams.n_layer) {
             fprintf(stderr, "%s: [old cublas] offloading output layer to GPU\n", __func__);
-            ggml_v2_cuda_transform_tensor(model.output); vram_total += ggml_v2_nbytes(model.output);
+            kcpp_backend_cuda_ggmlv2_transform_tensor(model.output); vram_total += ggml_v2_nbytes(model.output);
         }
 
         fprintf(stderr, "%s: [old cublas] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
@@ -1104,45 +1098,6 @@ static void llama_v2_model_load_internal(
             }
         }
     }
-#elif defined(GGML_USE_CLBLAST)
-    {
-        const int n_gpu = std::min(n_gpu_layers, int(hparams.n_layer));
-        if(GetQuantsUnshuffled())
-        {
-
-        fprintf(stderr, "%s: [opencl] offloading %d layers to GPU\n", __func__, n_gpu);
-
-        size_t vram_total = 0;
-
-        for (int i = 0; i < n_gpu; ++i) {
-            const auto & layer = model.layers[i];
-
-            ggml_v2_cl_transform_tensor(layer.wq); vram_total += ggml_v2_nbytes(layer.wq);
-            ggml_v2_cl_transform_tensor(layer.wk); vram_total += ggml_v2_nbytes(layer.wk);
-            ggml_v2_cl_transform_tensor(layer.wv); vram_total += ggml_v2_nbytes(layer.wv);
-            ggml_v2_cl_transform_tensor(layer.wo); vram_total += ggml_v2_nbytes(layer.wo);
-            ggml_v2_cl_transform_tensor(layer.w1); vram_total += ggml_v2_nbytes(layer.w1);
-            ggml_v2_cl_transform_tensor(layer.w2); vram_total += ggml_v2_nbytes(layer.w2);
-            ggml_v2_cl_transform_tensor(layer.w3); vram_total += ggml_v2_nbytes(layer.w3);
-        }
-        if (n_gpu_layers > (int) hparams.n_layer) {
-            fprintf(stderr, "%s: [opencl] offloading output layer to GPU\n", __func__);
-            ggml_v2_cl_transform_tensor(model.output); vram_total += ggml_v2_nbytes(model.output);
-        }
-
-        fprintf(stderr, "%s: [opencl] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        }
-        else
-        {
-            if(n_gpu>0)
-            {
-                printf("\n[WARNING: Old format does not support GPU offloading! It will be deactivated!]\n");
-            }
-        }
-    }
-#else
-    (void) n_gpu_layers;
-#endif
 
     // loading time will be recalculate after the first eval, so
     // we take page faults deferred by mmap() into consideration

--- a/otherarch/llama_v3.cpp
+++ b/otherarch/llama_v3.cpp
@@ -13,12 +13,7 @@
 
 #include "ggml_v3.h"
 #include "otherarch.h"
-#ifdef GGML_USE_CUDA
-#include "ggml_v3-cuda.h"
-#endif
-#if defined(GGML_USE_CLBLAST)
-#include "ggml_v3-opencl.h"
-#endif
+#include "kcpp_backend.h"
 
 
 #ifdef GGML_USE_K_QUANTS
@@ -61,12 +56,16 @@ static void llama_v3_log_callback_default(llama_v3_log_level level, const char *
 #define LLAMA_V3_LOG_WARN(...)  llama_v3_log_internal(LLAMA_V3_LOG_LEVEL_WARN , __VA_ARGS__)
 #define LLAMA_V3_LOG_ERROR(...) llama_v3_log_internal(LLAMA_V3_LOG_LEVEL_ERROR, __VA_ARGS__)
 
-#if !defined(GGML_USE_CUDA)
-#define LLAMA_V3_USE_ALLOCATOR
-#else
-#define LLAMA_V3_USE_SCRATCH
+
+static bool llama_v3_use_allocator() {
+    return !kcpp_backend_check(KCPP_BACKENDS_USE_CUDA);
+}
+
+static bool llama_v3_use_scratch() {
+    return kcpp_backend_check(KCPP_BACKENDS_USE_CUDA);
+}
+
 #define LLAMA_V3_MAX_SCRATCH_BUFFERS 16
-#endif
 
 
 // available llama models
@@ -270,10 +269,10 @@ struct llama_v3_kv_cache {
             ggml_v3_free(ctx);
         }
 
-#ifdef GGML_USE_CUDA
-        ggml_v3_cuda_free_data(k);
-        ggml_v3_cuda_free_data(v);
-#endif // GGML_USE_CUDA
+        if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
+        kcpp_backend_cuda_ggmlv3_free_data(k);
+        kcpp_backend_cuda_ggmlv3_free_data(v);
+        }
     }
 };
 
@@ -329,16 +328,12 @@ struct llama_v3_model {
             ggml_v3_free(ctx);
         }
 
-#ifdef GGML_USE_CUDA
+        if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
         for (size_t i = 0; i < tensors_by_name.size(); ++i) {
-            ggml_v3_cuda_free_data(tensors_by_name[i].second);
+            kcpp_backend_cuda_ggmlv3_free_data(tensors_by_name[i].second);
         }
-        ggml_v3_cuda_free_scratch();
-#elif defined(GGML_USE_CLBLAST)
-        for (size_t i = 0; i < tensors_by_name.size(); ++i) {
-            ggml_v3_cl_free_data(tensors_by_name[i].second);
+        kcpp_backend_cuda_ggmlv3_free_scratch();
         }
-#endif
     }
 };
 
@@ -349,11 +344,9 @@ struct llama_v3_context {
             delete &model;
         }
 
-#ifdef LLAMA_V3_USE_ALLOCATOR
         if (alloc) {
             ggml_v3_allocr_free(alloc);
         }
-#endif
     }
 
     std::mt19937 rng;
@@ -394,20 +387,16 @@ struct llama_v3_context {
     // TODO: move in llama_v3_state
     llama_v3_ctx_buffer buf_compute;
 
-#ifdef LLAMA_V3_USE_ALLOCATOR
     llama_v3_ctx_buffer buf_alloc;
     ggml_v3_allocr * alloc = NULL;
-#endif
 
-#ifdef LLAMA_V3_USE_SCRATCH
     llama_v3_ctx_buffer buf_scratch[LLAMA_V3_MAX_SCRATCH_BUFFERS];
     int    buf_last = 0;
     size_t buf_max_size[LLAMA_V3_MAX_SCRATCH_BUFFERS] = { 0 };
-#endif
 
 
     void use_buf(struct ggml_v3_context * ctx, int i) {
-#if defined(LLAMA_V3_USE_SCRATCH)
+        if (llama_v3_use_scratch()) {
         size_t last_size = 0;
 
         if (i == -1) {
@@ -422,19 +411,15 @@ struct llama_v3_context {
         }
 
         buf_last = i;
-#else
-        (void) i;
-        (void) ctx;
-#endif
+        }
     }
 
     size_t get_buf_max_mem(int i) const {
-#if defined(LLAMA_V3_USE_SCRATCH)
+        if (llama_v3_use_scratch()) {
         return buf_max_size[i];
-#else
-        (void) i;
+        } else {
         return 0;
-#endif
+        }
     }
 };
 
@@ -795,22 +780,16 @@ struct llama_v3_model_loader {
                         lmlock->grow_to(lock_size);
                     }
                     break;
-#if defined(GGML_USE_CUDA)
                 case GGML_V3_BACKEND_GPU:
                 case GGML_V3_BACKEND_GPU_SPLIT:
-                    ggml_v3_cuda_transform_tensor(lt.data, lt.ggml_v3_tensor);
+                    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
+                    kcpp_backend_cuda_ggmlv3_transform_tensor(lt.data, lt.ggml_v3_tensor);
                     if (!use_mmap) {
                         free(lt.data);
                     }
                     break;
-#elif defined(GGML_USE_CLBLAST)
-                case GGML_V3_BACKEND_GPU:
-                    ggml_v3_cl_transform_tensor(lt.data, lt.ggml_v3_tensor);
-                    if (!use_mmap) {
-                        free(lt.data);
                     }
-                    break;
-#endif
+                    // fallthrough
                 default:
                     continue;
             }
@@ -881,15 +860,14 @@ static bool kv_cache_init(
     ggml_v3_set_name(cache.k, "cache_k");
     ggml_v3_set_name(cache.v, "cache_v");
 
-    (void) n_gpu_layers;
-#ifdef GGML_USE_CUDA
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
     if (n_gpu_layers > n_layer + 1) {
-        ggml_v3_cuda_assign_buffers_no_scratch(cache.v);
+        kcpp_backend_cuda_ggmlv3_assign_buffers_no_scratch(cache.v);
     }
     if (n_gpu_layers > n_layer + 2) {
-        ggml_v3_cuda_assign_buffers_no_scratch(cache.k);
+        kcpp_backend_cuda_ggmlv3_assign_buffers_no_scratch(cache.k);
     }
-#endif // GGML_USE_CUDA
+    }
 
     return true;
 }
@@ -1179,22 +1157,17 @@ static void llama_v3_model_load_internal(
         }
     }
 
-    (void) main_gpu;
-    (void) mul_mat_q;
-#if defined(GGML_USE_CUDA)
+    enum ggml_v3_backend_type LLAMA_V3_BACKEND_OFFLOAD = GGML_V3_BACKEND_CPU;
+    enum ggml_v3_backend_type LLAMA_V3_BACKEND_OFFLOAD_SPLIT = GGML_V3_BACKEND_CPU;
+
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
     LLAMA_V3_LOG_INFO("%s: using CUDA for GPU acceleration\n", __func__);
-    ggml_v3_cuda_set_main_device(main_gpu);
-    ggml_v3_cuda_set_mul_mat_q(mul_mat_q);
-#define LLAMA_V3_BACKEND_OFFLOAD       GGML_V3_BACKEND_GPU
-#define LLAMA_V3_BACKEND_OFFLOAD_SPLIT GGML_V3_BACKEND_GPU_SPLIT
-#elif defined(GGML_USE_CLBLAST)
-    LLAMA_V3_LOG_INFO("%s: using OpenCL for GPU acceleration\n", __func__);
-#define LLAMA_V3_BACKEND_OFFLOAD       GGML_V3_BACKEND_GPU
-#define LLAMA_V3_BACKEND_OFFLOAD_SPLIT GGML_V3_BACKEND_GPU
-#else
-#define LLAMA_V3_BACKEND_OFFLOAD       GGML_V3_BACKEND_CPU
-#define LLAMA_V3_BACKEND_OFFLOAD_SPLIT GGML_V3_BACKEND_CPU
-#endif
+    printf("CUBLAS v3: Set main device to %d\n",main_gpu);
+    kcpp_backend_cuda_ggmlv3_set_main_device(main_gpu);
+    kcpp_backend_cuda_ggmlv3_set_mul_mat_q(mul_mat_q);
+    LLAMA_V3_BACKEND_OFFLOAD = GGML_V3_BACKEND_GPU;
+    LLAMA_V3_BACKEND_OFFLOAD_SPLIT = GGML_V3_BACKEND_GPU_SPLIT;
+    }
 
     // prepare memory for the weights
     size_t vram_weights = 0;
@@ -1282,12 +1255,12 @@ static void llama_v3_model_load_internal(
             ctx_size +
             mmapped_size - vram_weights; // weights in VRAM not in memory
 
-#ifndef LLAMA_V3_USE_ALLOCATOR
+        if (llama_v3_use_allocator()){
         mem_required +=
             blasbatchmul*MEM_REQ_SCRATCH0_3(hparams.n_ctx).at(model.type) +
             blasbatchmul*MEM_REQ_SCRATCH1_3().at(model.type) +
             blasbatchmul*MEM_REQ_EVAL_3().at(model.type);
-#endif
+        }
 
         // this is the memory required by one llama_v3_state
         const size_t mem_required_state =
@@ -1298,24 +1271,24 @@ static void llama_v3_model_load_internal(
 
         (void) vram_scratch;
         (void) n_batch;
-#ifdef GGML_USE_CUDA
+        if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
         if (low_vram) {
             LLAMA_V3_LOG_INFO("%s: not allocating a VRAM scratch buffer due to low VRAM option\n", __func__);
-            ggml_v3_cuda_set_scratch_size(0); // disable scratch
+            kcpp_backend_cuda_ggmlv3_set_scratch_size(0); // disable scratch
         } else {
             const size_t vram_scratch_base = VRAM_REQ_SCRATCH_BASE_3().at(model.type);
             const size_t vram_scratch_per_context = VRAM_REQ_SCRATCH_PER_CONTEXT_3().at(model.type);
             vram_scratch = n_batch * (vram_scratch_base + n_ctx * vram_scratch_per_context);
-            ggml_v3_cuda_set_scratch_size(vram_scratch);
+            kcpp_backend_cuda_ggmlv3_set_scratch_size(vram_scratch);
             if (n_gpu_layers > 0) {
                 LLAMA_V3_LOG_INFO("%s: allocating batch_size x (%zd kB + n_ctx x %zd B) = %zd MB VRAM for the scratch buffer\n",
                         __func__, vram_scratch_base / kB3, vram_scratch_per_context,
                         (vram_scratch + MB3 - 1) / MB3); // round up
             }
         }
-#endif // GGML_USE_CUDA
+        } // KCPP_BACKENDS_USE_CUDA
 
-#if defined(GGML_USE_CUDA) || defined(GGML_USE_CLBLAST)
+        if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
         const int n_gpu = std::min(n_gpu_layers, int(hparams.n_layer));
 
         LLAMA_V3_LOG_INFO("%s: offloading %d repeating layers to GPU\n", __func__, n_gpu);
@@ -1324,7 +1297,6 @@ static void llama_v3_model_load_internal(
         }
         size_t vram_kv_cache = 0;
 
-#ifdef GGML_USE_CUDA
         const int max_backend_supported_layers = hparams.n_layer + 3;
         const int max_offloadable_layers = low_vram ? hparams.n_layer + 1 : hparams.n_layer + 3;
         if (n_gpu_layers > (int) hparams.n_layer + 1) {
@@ -1343,18 +1315,12 @@ static void llama_v3_model_load_internal(
                 vram_kv_cache += hparams.kv_size() / 2;
             }
         }
-#elif defined(GGML_USE_CLBLAST)
-        const int max_backend_supported_layers = hparams.n_layer + 1;
-        const int max_offloadable_layers = hparams.n_layer + 1;
-#endif // GGML_USE_CUDA
 
         LLAMA_V3_LOG_INFO("%s: offloaded %d/%d layers to GPU\n",
                 __func__, std::min(n_gpu_layers, max_offloadable_layers), max_backend_supported_layers);
         LLAMA_V3_LOG_INFO("%s: total VRAM used: %zu MB\n",
                 __func__, (vram_weights + vram_scratch + vram_kv_cache + MB3 - 1) / MB3); // round up
-#else
-        (void) n_gpu_layers;
-#endif // defined(GGML_USE_CUDA) || defined(GGML_USE_CLBLAST)
+        } // KCPP_BACKENDS_USE_CUDA
     }
 
     // populate `tensors_by_name`
@@ -1362,12 +1328,10 @@ static void llama_v3_model_load_internal(
         model.tensors_by_name.emplace_back(lt.name, lt.ggml_v3_tensor);
     }
 
-    (void) tensor_split;
-#if defined(GGML_USE_CUDA)
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA))
     {
-        ggml_v3_cuda_set_tensor_split(tensor_split);
+        kcpp_backend_cuda_ggmlv3_set_tensor_split(tensor_split);
     }
-#endif
 
     ml->load_all_data(progress_callback, progress_callback_user_data, use_mlock ? &model.mlock_mmap : NULL);
 
@@ -1458,9 +1422,9 @@ static struct ggml_v3_cgraph * llama_v3_build_graph(
         /*.no_alloc   =*/ false,
     };
 
-#ifdef LLAMA_V3_USE_ALLOCATOR
+    if (llama_v3_use_allocator()) {
     params.no_alloc = true;
-#endif
+    }
 
     struct ggml_v3_context * ctx0 = ggml_v3_init(params);
 
@@ -1472,14 +1436,14 @@ static struct ggml_v3_cgraph * llama_v3_build_graph(
     if (tokens) {
         struct ggml_v3_tensor * inp_tokens = ggml_v3_new_tensor_1d(ctx0, GGML_V3_TYPE_I32, N);
 
-#ifdef LLAMA_V3_USE_ALLOCATOR
+      if (llama_v3_use_allocator()) {
         ggml_v3_allocr_alloc(lctx.alloc, inp_tokens);
         if (!ggml_v3_allocr_is_measure(lctx.alloc)) {
             memcpy(inp_tokens->data, tokens, N*ggml_v3_element_size(inp_tokens));
         }
-#else
+      } else {
         memcpy(inp_tokens->data, tokens, N*ggml_v3_element_size(inp_tokens));
-#endif
+      }
         ggml_v3_set_name(inp_tokens, "inp_tokens");
 
         inpL = ggml_v3_get_rows(ctx0, model.tok_embeddings, inp_tokens);
@@ -1488,14 +1452,14 @@ static struct ggml_v3_cgraph * llama_v3_build_graph(
 
         inpL = ggml_v3_new_tensor_2d(ctx0, GGML_V3_TYPE_F32, n_embd, N);
 
-#ifdef LLAMA_V3_USE_ALLOCATOR
+      if (llama_v3_use_allocator()) {
         ggml_v3_allocr_alloc(lctx.alloc, inpL);
         if (!ggml_v3_allocr_is_measure(lctx.alloc)) {
             memcpy(inpL->data, embd, N * n_embd * ggml_v3_element_size(inpL));
         }
-#else
+      } else {
         memcpy(inpL->data, embd, N * n_embd * ggml_v3_element_size(inpL));
-#endif
+      }
     }
 
     const int i_gpu_start = n_layer - n_gpu_layers;
@@ -1510,27 +1474,27 @@ static struct ggml_v3_cgraph * llama_v3_build_graph(
     offload_func_v3_t offload_func_kq = llama_v3_nop;
     offload_func_v3_t offload_func_v  = llama_v3_nop;
 
-#ifdef GGML_USE_CUDA
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
     if (n_gpu_layers > n_layer) {
-        offload_func_nr = ggml_v3_cuda_assign_buffers;
+        offload_func_nr = kcpp_backend_cuda_ggmlv3_assign_buffers;
     }
     if (n_gpu_layers > n_layer + 1) {
-        offload_func_v  = ggml_v3_cuda_assign_buffers;
+        offload_func_v  = kcpp_backend_cuda_ggmlv3_assign_buffers;
     }
     if (n_gpu_layers > n_layer + 2) {
-        offload_func_kq = ggml_v3_cuda_assign_buffers;
+        offload_func_kq = kcpp_backend_cuda_ggmlv3_assign_buffers;
     }
-#endif // GGML_USE_CUDA
+    } // KCPP_BACKENDS_USE_CUDA
 
     struct ggml_v3_tensor * KQ_scale = ggml_v3_new_tensor_1d(ctx0, GGML_V3_TYPE_F32, 1);
-#ifdef LLAMA_V3_USE_ALLOCATOR
+    if (llama_v3_use_allocator()) {
     ggml_v3_allocr_alloc(lctx.alloc, KQ_scale);
     if (!ggml_v3_allocr_is_measure(lctx.alloc)) {
         ggml_v3_set_f32(KQ_scale, 1.0f/sqrtf(float(n_embd)/n_head));
     }
-#else
+    } else {
     ggml_v3_set_f32(KQ_scale, 1.0f/sqrtf(float(n_embd)/n_head));
-#endif
+    }
 
     float KQ_scale_float = 1.0f/sqrtf(float(n_embd)/n_head);
 
@@ -1541,11 +1505,11 @@ static struct ggml_v3_cgraph * llama_v3_build_graph(
 
         offload_func_v3_t offload_func = llama_v3_nop;
 
-#ifdef GGML_USE_CUDA
+        if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
         if (il >= i_gpu_start) {
-            offload_func = ggml_v3_cuda_assign_buffers;
+            offload_func = kcpp_backend_cuda_ggmlv3_assign_buffers;
         }
-#endif // GGML_USE_CUDA
+        }
 
         struct ggml_v3_tensor * inpSA = inpL;
 
@@ -1577,7 +1541,7 @@ static struct ggml_v3_cgraph * llama_v3_build_graph(
             struct ggml_v3_tensor * KQ_pos = ggml_v3_new_tensor_1d(ctx0, GGML_V3_TYPE_I32, n_tokens);
             ggml_v3_set_name(KQ_pos, "KQ_pos");
 
-#ifdef LLAMA_V3_USE_ALLOCATOR
+            if (llama_v3_use_allocator()) {
             offload_func_kq(KQ_pos); //don't offload rope for cublas, its broken now since ring buffer was added
             ggml_v3_allocr_alloc(lctx.alloc, KQ_pos);
             if (!ggml_v3_allocr_is_measure(lctx.alloc)) {
@@ -1586,14 +1550,14 @@ static struct ggml_v3_cgraph * llama_v3_build_graph(
                     data[i] = n_past + i;
                 }
             }
-#else
+            } else {
             {
                 int * data = (int *) KQ_pos->data;
                 for (int i = 0; i < N; ++i) {
                     data[i] = n_past + i;
                 }
             }
-#endif
+            }
 
             struct ggml_v3_tensor *Kcur = ggml_v3_rope_custom_inplace(ctx0, ggml_v3_reshape_3d(ctx0, tmpk, n_embd_head, n_head_kv, N), KQ_pos, n_embd_head, 0, 0, 0, freq_base, freq_scale, 0, 1, 32, 1);
             offload_func_kq(Kcur);
@@ -3451,10 +3415,10 @@ struct llama_v3_context * llama_v3_new_context_with_model(
         ctx->buf_compute.resize(blasbatchmul*MEM_REQ_EVAL_3().at(ctx->model.type) + ggml_v3_graph_overhead());
 #endif
 
-#ifdef LLAMA_V3_USE_SCRATCH
+        if (llama_v3_use_scratch()) {
         ctx->buf_scratch[0].resize(blasbatchmul*MEM_REQ_SCRATCH0_3(hparams.n_ctx).at(ctx->model.type));
         ctx->buf_scratch[1].resize(blasbatchmul*MEM_REQ_SCRATCH1_3().at(ctx->model.type));
-#endif
+        }
     }
 
     return ctx;
@@ -3666,19 +3630,17 @@ int llama_v3_apply_lora_from_file_internal(const struct llama_v3_model & model, 
             offload_func_v3_t offload_func = llama_v3_nop;
             offload_func_v3_t offload_func_force_inplace = llama_v3_nop;
 
-#if defined(GGML_USE_CUDA) || defined(GGML_USE_CLBLAST)
+          if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
             if (dest_t->backend == GGML_V3_BACKEND_GPU || dest_t->backend == GGML_V3_BACKEND_GPU_SPLIT) {
                 if (dest_t->type != GGML_V3_TYPE_F16) {
                     printf("\nError: the simultaneous use of LoRAs and GPU acceleration is only supported for f16 models\n");
                     throw std::runtime_error(format_old(
                         "%s: error: lora failed", __func__));
                 }
-#if defined(GGML_USE_CUDA)
-                offload_func = ggml_v3_cuda_assign_buffers;
-                offload_func_force_inplace = ggml_v3_cuda_assign_buffers_force_inplace;
-#endif
+                offload_func = kcpp_backend_cuda_ggmlv3_assign_buffers;
+                offload_func_force_inplace = kcpp_backend_cuda_ggmlv3_assign_buffers_force_inplace;
             }
-#endif // GGML_USE_CUDA
+          }
 
             ggml_v3_tensor * base_t;
             if (model_loader) {

--- a/otherarch/mpt_v3.cpp
+++ b/otherarch/mpt_v3.cpp
@@ -15,13 +15,7 @@
 #include <algorithm>
 
 #include "model_adapter.h"
-
-#ifdef GGML_USE_CUDA
-#include "ggml_v3-cuda.h"
-#endif
-#if defined(GGML_USE_CLBLAST)
-#include "ggml_v3-opencl.h"
-#endif
+#include "kcpp_backend.h"
 
 // load the model's weights from a file
 bool mpt_model_load(const std::string & fname, mpt_model & model, gpt_vocab & vocab, int gpulayers) {
@@ -300,42 +294,27 @@ bool mpt_model_load(const std::string & fname, mpt_model & model, gpt_vocab & vo
     fin.close();
 
     //gpu offload
-    #if defined(GGML_USE_CLBLAST) || defined(GGML_USE_CUDA)
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
     if(gpulayers>0)
     {
         const auto & hparams = model.hparams;
         size_t vram_total = 0;
         const int n_gpu = std::min(gpulayers, int(hparams.n_layers));
-        #if defined(GGML_USE_CLBLAST)
-        fprintf(stderr, "%s: [opencl] offloading %d layers to GPU\n", __func__, n_gpu);
-        #else
         fprintf(stderr, "%s: [CUDA] offloading %d layers to GPU\n", __func__, n_gpu);
-        #endif
         for (int i = 0; i < n_gpu; ++i) {
             const auto & layer = model.layers[i];
             layer.ffn_up_proj->backend = GGML_V3_BACKEND_GPU;
             layer.ffn_down_proj->backend = GGML_V3_BACKEND_GPU;
             layer.c_attn_wqkv_weight->backend = GGML_V3_BACKEND_GPU;
             layer.c_attn_out_proj_weight->backend = GGML_V3_BACKEND_GPU;
-            #if defined(GGML_USE_CLBLAST)
-            ggml_v3_cl_transform_tensor(layer.ffn_up_proj->data,layer.ffn_up_proj); vram_total += ggml_v3_nbytes(layer.ffn_up_proj);
-            ggml_v3_cl_transform_tensor(layer.ffn_down_proj->data,layer.ffn_down_proj); vram_total += ggml_v3_nbytes(layer.ffn_down_proj);
-            ggml_v3_cl_transform_tensor(layer.c_attn_wqkv_weight->data,layer.c_attn_wqkv_weight); vram_total += ggml_v3_nbytes(layer.c_attn_wqkv_weight);
-            ggml_v3_cl_transform_tensor(layer.c_attn_out_proj_weight->data,layer.c_attn_out_proj_weight); vram_total += ggml_v3_nbytes(layer.c_attn_out_proj_weight);
-            #else
-            ggml_v3_cuda_transform_tensor(layer.ffn_up_proj->data,layer.ffn_up_proj); vram_total += ggml_v3_nbytes(layer.ffn_up_proj);
-            ggml_v3_cuda_transform_tensor(layer.ffn_down_proj->data,layer.ffn_down_proj); vram_total += ggml_v3_nbytes(layer.ffn_down_proj);
-            ggml_v3_cuda_transform_tensor(layer.c_attn_wqkv_weight->data,layer.c_attn_wqkv_weight); vram_total += ggml_v3_nbytes(layer.c_attn_wqkv_weight);
-            ggml_v3_cuda_transform_tensor(layer.c_attn_out_proj_weight->data,layer.c_attn_out_proj_weight); vram_total += ggml_v3_nbytes(layer.c_attn_out_proj_weight);
-            #endif
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.ffn_up_proj->data,layer.ffn_up_proj); vram_total += ggml_v3_nbytes(layer.ffn_up_proj);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.ffn_down_proj->data,layer.ffn_down_proj); vram_total += ggml_v3_nbytes(layer.ffn_down_proj);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_wqkv_weight->data,layer.c_attn_wqkv_weight); vram_total += ggml_v3_nbytes(layer.c_attn_wqkv_weight);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_out_proj_weight->data,layer.c_attn_out_proj_weight); vram_total += ggml_v3_nbytes(layer.c_attn_out_proj_weight);
         }
-        #if defined(GGML_USE_CLBLAST)
-            fprintf(stderr, "%s: [opencl] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #else
-            fprintf(stderr, "%s: [CUDA] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #endif
+        fprintf(stderr, "%s: [CUDA] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
     }
-    #endif
+    }
 
     return true;
 }

--- a/otherarch/neox_v3.cpp
+++ b/otherarch/neox_v3.cpp
@@ -14,12 +14,7 @@
 #include <iostream>
 #include <algorithm>
 
-#ifdef GGML_USE_CUDA
-#include "ggml_v3-cuda.h"
-#endif
-#if defined(GGML_USE_CLBLAST)
-#include "ggml_v3-opencl.h"
-#endif
+#include "kcpp_backend.h"
 
 // load the model's weights from a file
 ModelLoadResult gpt_neox_model_load(const std::string & fname, gpt_neox_model & model, gpt_vocab & vocab, FileFormat file_format, int gpulayers) {
@@ -334,42 +329,27 @@ ModelLoadResult gpt_neox_model_load(const std::string & fname, gpt_neox_model & 
     fin.close();
 
     //gpu offload
-    #if defined(GGML_USE_CLBLAST) || defined(GGML_USE_CUDA)
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA)) {
     if(gpulayers>0)
     {
         const auto & hparams = model.hparams;
         size_t vram_total = 0;
         const int n_gpu = std::min(gpulayers, int(hparams.n_layer));
-        #if defined(GGML_USE_CLBLAST)
-        fprintf(stderr, "%s: [opencl] offloading %d layers to GPU\n", __func__, n_gpu);
-        #else
         fprintf(stderr, "%s: [CUDA] offloading %d layers to GPU\n", __func__, n_gpu);
-        #endif
         for (int i = 0; i < n_gpu; ++i) {
             const auto & layer = model.layers[i];
             layer.c_attn_attn_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_attn_proj_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_mlp_fc_w->backend = GGML_V3_BACKEND_GPU;
             layer.c_mlp_proj_w->backend = GGML_V3_BACKEND_GPU;
-            #if defined(GGML_USE_CLBLAST)
-            ggml_v3_cl_transform_tensor(layer.c_attn_attn_w->data,layer.c_attn_attn_w); vram_total += ggml_v3_nbytes(layer.c_attn_attn_w);
-            ggml_v3_cl_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
-            ggml_v3_cl_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
-            ggml_v3_cl_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
-            #else
-            ggml_v3_cuda_transform_tensor(layer.c_attn_attn_w->data,layer.c_attn_attn_w); vram_total += ggml_v3_nbytes(layer.c_attn_attn_w);
-            ggml_v3_cuda_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
-            ggml_v3_cuda_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
-            ggml_v3_cuda_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
-            #endif
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_attn_w->data,layer.c_attn_attn_w); vram_total += ggml_v3_nbytes(layer.c_attn_attn_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_attn_proj_w->data,layer.c_attn_proj_w); vram_total += ggml_v3_nbytes(layer.c_attn_proj_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_mlp_fc_w->data,layer.c_mlp_fc_w); vram_total += ggml_v3_nbytes(layer.c_mlp_fc_w);
+            kcpp_backend_cuda_ggmlv3_transform_tensor(layer.c_mlp_proj_w->data,layer.c_mlp_proj_w); vram_total += ggml_v3_nbytes(layer.c_mlp_proj_w);
         }
-        #if defined(GGML_USE_CLBLAST)
-            fprintf(stderr, "%s: [opencl] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #else
-            fprintf(stderr, "%s: [CUDA] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
-        #endif
+        fprintf(stderr, "%s: [CUDA] total VRAM used: %zu MB\n", __func__, vram_total / 1024 / 1024);
     }
-    #endif
+    }
 
     return ModelLoadResult::SUCCESS;
 }

--- a/otherarch/rwkv_v3.cpp
+++ b/otherarch/rwkv_v3.cpp
@@ -6,13 +6,6 @@
 #include "rwkv_v3.h"
 #include "ggml_v3.h"
 
-#ifdef GGML_USE_CUDA
-#include "ggml_v3-cuda.h"
-#endif
-#if defined(GGML_USE_CLBLAST)
-#include "ggml_v3-opencl.h"
-#endif
-
 #include "utils.h"
 
 #include <string>
@@ -1076,11 +1069,11 @@ struct rwkv_future_tensor rwkv_future_graph_work(struct rwkv_future_ctx & ctx,
     const size_t n_threads,
     const size_t sequence_len = 1
 ) {
-#if defined(GGML_USE_CLBLAST) || defined(GGML_USE_CUDA)
-    enum ggml_v3_type mul_mat_type = type == GGML_V3_TYPE_F32 ? GGML_V3_TYPE_F32 : GGML_V3_TYPE_F16;
-#else
-    enum ggml_v3_type mul_mat_type = ggml_v3_is_quantized(type) ? GGML_V3_TYPE_Q8_1 : type;
-#endif
+    enum ggml_v3_type mul_mat_type;
+    if(kcpp_backend_check(KCPP_BACKENDS_USE_CUDA))
+        mul_mat_type = type == GGML_V3_TYPE_F32 ? GGML_V3_TYPE_F32 : GGML_V3_TYPE_F16;
+    else
+        mul_mat_type = ggml_v3_is_quantized(type) ? GGML_V3_TYPE_Q8_1 : type;
     return ctx.alloc(GGML_V3_TYPE_I8, rwkv_future_tensor::size(mul_mat_type, ffn_key_height, sequence_len) * n_threads + 64 * (n_threads - 1));
 }
 
@@ -1566,16 +1559,13 @@ struct rwkv_context * rwkv_clone_context(struct rwkv_context * ctx, const uint32
 }
 
 bool rwkv_gpu_offload_layers(struct rwkv_context * ctx, const uint32_t n_layers) {
-#if defined(GGML_USE_CLBLAST) || defined(GGML_USE_CUDA)
+    if (!kcpp_backend_check(KCPP_BACKENDS_USE_CUDA))
+        return false;
     printf("\nOffloading %u (or fewer) layers...",n_layers);
     const auto offload = [&](struct ggml_v3_tensor * tensor) {
         // TODO support multi-GPU
         tensor->backend = GGML_V3_BACKEND_GPU;
-        #if defined(GGML_USE_CLBLAST)
-        ggml_v3_cl_transform_tensor(tensor->data, tensor);
-        #else
-        ggml_v3_cuda_transform_tensor(tensor->data, tensor);
-        #endif
+        kcpp_backend_cuda_ggmlv3_transform_tensor(tensor->data, tensor);
     };
 
     const size_t n_gpu = std::min(n_layers, ctx->instance->model.header.n_layer);
@@ -1597,7 +1587,6 @@ bool rwkv_gpu_offload_layers(struct rwkv_context * ctx, const uint32_t n_layers)
 
         return true;
     }
-#endif
     return false;
 }
 

--- a/otherarch/whispercpp/whisper.cpp
+++ b/otherarch/whispercpp/whisper.cpp
@@ -4,21 +4,7 @@
 #include "coreml/whisper-encoder.h"
 #endif
 
-#ifdef GGML_USE_METAL
-#include "ggml-metal.h"
-#endif
-
-#ifdef GGML_USE_CUDA
-#include "ggml-cuda.h"
-#endif
-
-#ifdef GGML_USE_VULKAN
-#include "ggml-vulkan.h"
-#endif
-
-#ifdef GGML_USE_SYCL
-#include "ggml-sycl.h"
-#endif
+#include "kcpp_backend.h"
 
 #ifdef WHISPER_USE_OPENVINO
 #include "openvino/whisper-openvino-encoder.h"
@@ -209,7 +195,8 @@ static bool ggml_graph_compute_helper(
 // and X_1 and Y_1 are the remaining views. X_1 and Y_1 end up being small matrices that can be processed with more
 // general-purpose kernels
 //
-static struct ggml_tensor * ggml_mul_mat_pad(struct ggml_context * ctx, struct ggml_tensor * x, struct ggml_tensor * y, int pad = 32) {
+static struct ggml_tensor * ggml_mul_mat_pad(struct ggml_context * ctx, struct ggml_tensor * x, struct ggml_tensor * y) {
+    const int pad = 32;
     // use padding only if dimension 0 is at least 8 times larger than the padding
     // else we won't get much benefit from the optimization
     const int n_pad_req = 8;
@@ -229,11 +216,12 @@ static struct ggml_tensor * ggml_mul_mat_pad(struct ggml_context * ctx, struct g
             ggml_mul_mat(ctx, x_1, y_1));
 }
 
+static struct ggml_tensor * ggml_mul_mat_original(struct ggml_context * ctx, struct ggml_tensor * x, struct ggml_tensor * y) {
+    return ggml_mul_mat(ctx, x, y);
+}
+
 // TODO: check if other platforms can benefit from this optimization
 // TODO: CUDA is currently broken - seems ggml_mul_mat does not handle views correctly
-#if defined(GGML_USE_METAL)
-#define ggml_mul_mat ggml_mul_mat_pad
-#endif
 
 // available whisper models
 enum e_model {
@@ -1082,17 +1070,13 @@ static uint32_t whisper_kv_cache_get_padding(const struct whisper_context & wctx
         return 1u;
     }
 
-#ifdef GGML_USE_METAL
-    if (ggml_backend_is_metal(wctx.backend)) {
+    if (kcpp_backend_check("mtl", wctx.backend)) {
         return 32u;
     }
-#endif
 
-#ifdef GGML_USE_CUDA
-    if (ggml_backend_is_cuda(wctx.backend)) {
+    if (kcpp_backend_check(KCPP_BACKENDS_USE_CUDA, wctx.backend)) {
         return 256u;
     }
-#endif
 
     return 1u;
 }
@@ -1231,50 +1215,24 @@ static size_t aheads_masks_nbytes(struct whisper_aheads_masks & aheads_masks) {
 static ggml_backend_t whisper_backend_init(const whisper_context_params & params) {
     ggml_backend_t backend_gpu = NULL;
 
-    // initialize the backends
-#ifdef GGML_USE_CUDA
     if (params.use_gpu) {
-        WHISPER_LOG_INFO("%s: using CUDA backend\n", __func__);
-        backend_gpu = ggml_backend_cuda_init(params.gpu_device);
-        if (!backend_gpu) {
-            WHISPER_LOG_ERROR("%s: ggml_backend_cuda_init() failed\n", __func__);
+        auto device = kcpp_backend_get_device(params.gpu_device);
+        if (!device) {
+            WHISPER_LOG_ERROR("%s: couldn't get device %d\n", __func__, params.gpu_device);
+        } else {
+            WHISPER_LOG_INFO("%s: using backend %s\n", __func__, ggml_backend_dev_name(device));
+            backend_gpu = ggml_backend_dev_init(device, nullptr);
+            if (!backend_gpu) {
+                WHISPER_LOG_ERROR("%s: ggml_backend_dev_init() failed\n", __func__);
+            } else {
+                if (kcpp_backend_check("mtl", backend_gpu) && !kcpp_backend_metal_supports_family(backend_gpu, 7)) {
+                    WHISPER_LOG_ERROR("%s: Metal GPU does not support family 7 - falling back to CPU\n", __func__);
+                    ggml_backend_free(backend_gpu);
+                    backend_gpu = NULL;
+                }
+            }
         }
     }
-#endif
-
-#ifdef GGML_USE_METAL
-    if (params.use_gpu) {
-        WHISPER_LOG_INFO("%s: using Metal backend\n", __func__);
-        backend_gpu = ggml_backend_metal_init();
-        if (!backend_gpu) {
-            WHISPER_LOG_ERROR("%s: ggml_backend_metal_init() failed\n", __func__);
-        } else if (!ggml_backend_metal_supports_family(backend_gpu, 7)) {
-            WHISPER_LOG_ERROR("%s: Metal GPU does not support family 7 - falling back to CPU\n", __func__);
-            ggml_backend_free(backend_gpu);
-            backend_gpu = NULL;
-        }
-    }
-#endif
-
-#ifdef GGML_USE_SYCL
-    if (params.use_gpu) {
-        WHISPER_LOG_INFO("%s: using SYCL backend\n", __func__);
-        backend_gpu = ggml_backend_sycl_init(params.gpu_device);
-        if (!backend_gpu) {
-            WHISPER_LOG_ERROR("%s: ggml_backend_sycl_init() failed\n", __func__);
-        }
-    }
-#endif
-
-#ifdef GGML_USE_VULKAN
-    if (params.use_gpu) {
-        WHISPER_LOG_INFO("%s: using Vulkan backend\n", __func__);
-        backend_gpu = ggml_backend_vk_init(params.gpu_device);
-        if (!backend_gpu) {
-            WHISPER_LOG_ERROR("%s: ggml_backend_vk_init() failed\n", __func__);
-        }
-    }
-#endif
 
     if (backend_gpu) {
         return backend_gpu;
@@ -1902,6 +1860,11 @@ static struct ggml_cgraph * whisper_build_graph_conv(
 static struct ggml_cgraph * whisper_build_graph_encoder(
         whisper_context & wctx,
           whisper_state & wstate) {
+
+    auto ggml_mul_mat = kcpp_backend_check("mtl", wctx.backend)
+                        ? ggml_mul_mat_pad
+                        : ggml_mul_mat_original;
+
     const auto & model   = wctx.model;
     const auto & hparams = model.hparams;
 
@@ -2147,6 +2110,11 @@ static struct ggml_cgraph * whisper_build_graph_encoder(
 static struct ggml_cgraph * whisper_build_graph_cross(
         whisper_context & wctx,
           whisper_state & wstate) {
+
+    auto ggml_mul_mat = kcpp_backend_check("mtl", wctx.backend)
+                        ? ggml_mul_mat_pad
+                        : ggml_mul_mat_original;
+
     const auto & model   = wctx.model;
     const auto & hparams = model.hparams;
 
@@ -2334,6 +2302,11 @@ static struct ggml_cgraph * whisper_build_graph_decoder(
      const whisper_batch & batch,
                     bool   save_alignment_heads_QKs,
                     bool   worst_case) {
+
+    auto ggml_mul_mat = kcpp_backend_check("mtl", wctx.backend)
+                        ? ggml_mul_mat_pad
+                        : ggml_mul_mat_original;
+
     const auto & model   = wctx.model;
     const auto & hparams = model.hparams;
 
@@ -6591,6 +6564,11 @@ WHISPER_API int whisper_bench_ggml_mul_mat(int n_threads) {
 }
 
 WHISPER_API const char * whisper_bench_ggml_mul_mat_str(int n_threads) {
+
+    auto ggml_mul_mat = kcpp_backend_check("mtl")
+                        ? ggml_mul_mat_pad
+                        : ggml_mul_mat_original;
+
     static std::string s;
     s = "";
     char strbuf[256];


### PR DESCRIPTION
This is an initial attempt to replace build-time backend checks with runtime ones.

My main intention is to _eventually_ be able to decouple all code from fixed ggml backends, which would give us the ability to have a distributed binary for any CPU instruction set, use more than one GPU backend type at the same time, etc. But even if that's not achievable (or desired!), I believe Koboldcpp can still benefit from changes in that direction: reduced build times, lower chance of building OK on one backend and failing on another, smaller binaries, etc.

I'm submitting very early to validate the approach before spending too much time on this, so right now it only replaces some easier parts of `gpttype_adapter`: checks for tensor splitting, BLAS support, etc. I've also refactored the tensor splitting check to avoid a bit of repetitive code.

The runtime backend tests are very similar to the ones used by stable-diffusion.cpp, identifying the backends by their names (with a bit of convenience code to be able to check several at once). Right now, I'm always checking the first device, so it should give the same results as the compile-time checks; but the API is already prepared to accept backend pointers.

There should be only one functional change: the check

```c++
    #if defined(GGML_USE_CUDA)
    mtmd_fa = LLAMA_FLASH_ATTN_TYPE_DISABLED; //kcpp: disabled in 1.102.2 as some headsizes break on turing
    #endif
```

also triggered for ROCm; so I've replaced it with a straight CUDA-only check.
