### PR TITLE
fix(console): terminate generation stats line with a newline (#2285)

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -5381,7 +5381,7 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
     float pt2 = (gen_time*1000.0/(real_n_generated<=0?1:real_n_generated));
     float generated_tps = (pt2>0?(1000.0/pt2):0);
     float total_time = (init_time + process_time + gen_time);
-    printf("\n[%s] CtxLimit:%d/%d, Init:%.2fs, Processed:%d in %.2fs (%.2fT/s), Generated:%d/%d in %.2fs (%.2fT/s), Total:%.2fs",
+    printf("\n[%s] CtxLimit:%d/%d, Init:%.2fs, Processed:%d in %.2fs (%.2fT/s), Generated:%d/%d in %.2fs (%.2fT/s), Total:%.2fs\n",
     get_timestamp_str().c_str(),(int)current_context_tokens.size(),(int)nctx, init_time, real_n_processed, process_time, processed_tps, real_n_generated, kcpp_data->n_predict, gen_time, generated_tps, total_time);
 
     if(debugmode==1 && !is_quiet && (draft_successes+draft_failures)>0)


### PR DESCRIPTION
## Summary

Fixes #2285 — the post-generation stats line runs into the next log message with no line break:

```
... Total:4.23sstate_write_data: writing state
```

## Cause

The stats line in `gpttype_adapter.cpp` is printed with a **leading** `\n` and no **trailing** one:

```c
printf("\n[%s] CtxLimit:%d/%d, Init:%.2fs, ... Total:%.2fs", ...);
```

This relies on the *next* koboldcpp print also starting with `\n`. But llama.cpp's `state_write_data: writing state` message (emitted when save-state runs right after generation) has no leading newline, so it gets glued onto the end of the stats line.

Since that message comes from vendored llama.cpp, the correct-layer fix is to terminate koboldcpp's own stats line.

## Fix

Append `\n` to the stats `printf` format string so the line is always terminated regardless of what prints next. One-character change, no behavioral impact on the numbers reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
