### PR TITLE
sd: make aborting on client disconnect opt-out

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -7510,7 +7510,11 @@ Change Mode<br>
                             if loras:
                                 genparams['prompt'] = prompt
                                 genparams['lora'] = lora_map_name_to_path(loras)
-                        gen = asyncio.run(self.handle_image_request(sd_generate, genparams, handle.sd_abort_generation))
+                        abort_gen = handle.sd_abort_generation
+                        override_abort_gen = genparams.get('kcpp_extra_args', {}).get('keep_image_gen_on_disconnect', gendefaults.get('keep_image_gen_on_disconnect'))
+                        if override_abort_gen is not None and not tryparseint(override_abort_gen, 1):
+                            abort_gen = None
+                        gen = asyncio.run(self.handle_image_request(sd_generate, genparams, abort_gen))
                         gendat = gen["data"]
                         genanim = gen["animated"]
                         gendatextra = gen["data_extra"]


### PR DESCRIPTION
Allow disabling the abort-on-disconnect behavior through a new API field, that can also be overrided by `gendefaults`.

Not so sure about the `kcpp_extra_args` nesting, but it seems sensible to scope Koboldcpp-specific options like this.