### PR TITLE
fix(api): don't iterate a string banned_tokens character by character (#2333)

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2048,7 +2048,11 @@ def generate(genparams, stream_flag=False):
     logit_biases = genparams.get('logit_bias', {})
     render_special = genparams.get('render_special', False)
     banned_strings = genparams.get('banned_strings', []) # SillyTavern uses that name
+    if isinstance(banned_strings, str): # a bare string gets iterated character by character, banning individual letters
+        banned_strings = [banned_strings] if banned_strings else []
     banned_tokens = genparams.get('banned_tokens', banned_strings)
+    if isinstance(banned_tokens, str):
+        banned_tokens = [banned_tokens] if banned_tokens else []
     bypass_eos_token = genparams.get('bypass_eos', False)
     tool_call_fix = genparams.get('using_openai_tools', False)
     custom_token_bans = genparams.get('custom_token_bans', '')

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -1983,6 +1983,23 @@ def load_model(model_filename):
     ret = handle.load_model(inputs)
     return ret
 
+def coerce_ban_list(value):
+    # banned tokens/strings are consumed as a list of substrings. A bare string satisfies
+    # every operation there, but iterates character by character, banning single letters.
+    if not value:
+        return []
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if stripped.startswith('[') and stripped.endswith(']'): # a JSON array sent as a string, e.g. through gendefaults
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+        except json.JSONDecodeError:
+            pass
+    return [value]
+
 def generate(genparams, stream_flag=False):
     global maxctx, args, currentusergenkey, totalgens, pendingabortkey
     default_adapter = {} if chatcompl_adapter is None else chatcompl_adapter
@@ -2047,12 +2064,8 @@ def generate(genparams, stream_flag=False):
         min_p = 0.002
     logit_biases = genparams.get('logit_bias', {})
     render_special = genparams.get('render_special', False)
-    banned_strings = genparams.get('banned_strings', []) # SillyTavern uses that name
-    if isinstance(banned_strings, str): # a bare string gets iterated character by character, banning individual letters
-        banned_strings = [banned_strings] if banned_strings else []
-    banned_tokens = genparams.get('banned_tokens', banned_strings)
-    if isinstance(banned_tokens, str):
-        banned_tokens = [banned_tokens] if banned_tokens else []
+    banned_strings = coerce_ban_list(genparams.get('banned_strings', [])) # SillyTavern uses that name
+    banned_tokens = coerce_ban_list(genparams.get('banned_tokens', banned_strings))
     bypass_eos_token = genparams.get('bypass_eos', False)
     tool_call_fix = genparams.get('using_openai_tools', False)
     custom_token_bans = genparams.get('custom_token_bans', '')


### PR DESCRIPTION
Fixes #2333.

## Root cause

`banned_tokens` / `banned_strings` are consumed as a **list of substrings**:

```python
banned_tokens = banned_tokens[:ban_token_max]
inputs.banned_tokens_len = len(banned_tokens)
for n, tok in enumerate(banned_tokens):
    inputs.banned_tokens[n] = tok.encode("UTF-8")
```

Nothing checks the type. A Python string satisfies every operation here — slicing, `len()`, and iteration all "work" — but iteration walks it **one character at a time**, so each individual letter becomes its own banned substring.

The reporter's config supplied the value as a JSON-encoded string rather than a list:

```json
"gendefaults": { "banned_tokens": "[\"exclude\"]" }
```

which expands to 11 single-character bans:

```
'[', '"', 'e', 'x', 'c', 'l', 'u', 'd', 'e', '"', ']'
```

Banning `e`, `c`, `l`, `u`, `d` makes most English words unreachable, which is why the output degenerated (`1 + 1 = 2of` followed by Hindi) rather than failing outright. This also explains why it reproduced across Gemma 4 / Qwen 3.5, CUDA / Vulkan / CPU, and with or without Jinja — it happens in the Python layer, before anything reaches the backend.

## Fix

`coerce_ban_list` normalizes the value before it reaches the ctypes loop:

- a list passes through untouched;
- a string delimited by `[` `]` that parses as a JSON list becomes that list — this is the reported case, and it makes the OP's config ban `exclude` as they intended;
- any other string becomes a single-element list, so a bare `"exclude"` bans the word rather than its letters;
- empty / absent stays a no-op.

Restricting JSON parsing to `[`-delimited strings that actually parse keeps it from guessing at ordinary substrings, and mirrors the leniency `parse_json_object` already applies to loosely-formatted JSON elsewhere in the file.

## Behavior

| input | before | after |
|---|---|---|
| `["exclude"]` (list) | bans `exclude` | unchanged |
| `"exclude"` (string) | bans `e`,`x`,`c`,`l`,`u`,`d` | bans `exclude` |
| `"[\"exclude\"]"` (issue #2333) | bans 11 characters → garbage | bans `exclude` |
| `"[not json]"` | bans 10 characters | bans the literal `[not json]` |
| `""` / absent | no-op | no-op |

`banned_strings` is coerced too, since `banned_tokens` falls back to it.

Scope is limited to `banned_tokens`/`banned_strings`. Note `stop_sequence` has the same character-iteration hazard for native-API callers, but that's outside this issue — glad to follow up separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
