### PR TITLE
fix(console): print websearch status on its own line (#2337)

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -2981,13 +2981,13 @@ def websearch(query):
         return []
     query = query[:300] # only search first 300 chars, due to search engine limits
     if query==websearch_lastquery:
-        print("Returning cached websearch...")
+        print("\nReturning cached websearch...")
         return websearch_lastresponse
     import difflib
     from html.parser import HTMLParser
     num_results = 3
     searchresults = []
-    utfprint("Performing new websearch...",1)
+    utfprint("\nPerforming new websearch...",1)
 
     def fetch_searched_webpage(url, random_agent=False):
         from urllib.parse import quote, urlsplit, urlunsplit


### PR DESCRIPTION
## Summary

Fixes #2337 — the two websearch status messages print with no leading newline, so they run onto the end of the preceding generation-stats line (which is printed with a leading `\n` and no trailing one), producing output like:

```
[11:20:56] CtxLimit:1735/32768, ... Total:26.31sReturning cached websearch...
```

## Cause

In `websearch()` the status lines are printed without a leading newline:

```python
print("Returning cached websearch...")
...
utfprint("Performing new websearch...",1)
```

Because the stats line in `gpttype_adapter.cpp` ends without a newline, these messages append to its tail. (In quiet mode only the plain `print(...)` shows, which is why the report shows the cached-result line.)

## Fix

Add a leading `\n` to both websearch status prints so each starts on its own line. This mirrors the approach already used elsewhere for the same class of issue (adding the missing newline at the offending print rather than restructuring the stats line, cf. the fix for #2285), so it does **not** introduce a double newline on the common path.

Before:
```
...Total:26.31sReturning cached websearch...
```
After:
```
...Total:26.31s
Returning cached websearch...
```

Verified the module still parses (`python -m ast`). No other behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
