### PR TITLE
fix: give each IP listener a full worker pool

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -7724,6 +7724,15 @@ Change Mode<br>
             self.send_header('content-type', content_type)
         return super(KcppServerRequestHandler, self).end_headers()
 
+def _get_listener_thread_sockets(ipv4_sock, ipv6_sock, threads_per_listener):
+    return [
+        server_socket
+        for server_socket in (ipv4_sock, ipv6_sock)
+        if server_socket is not None
+        for _ in range(threads_per_listener)
+    ]
+
+
 def RunServerMultiThreaded(addr, port, server_handler):
     global exitcounter, sslvalid, global_memory
     if is_port_in_use(port):
@@ -7764,9 +7773,9 @@ def RunServerMultiThreaded(addr, port, server_handler):
             print("IPv6 Socket Failed to Bind. IPv6 will be unavailable.")
 
     class Thread(threading.Thread):
-        def __init__(self, i):
+        def __init__(self, server_socket):
             threading.Thread.__init__(self)
-            self.i = i
+            self.server_socket = server_socket
             self.daemon = True
             self.start()
 
@@ -7775,15 +7784,7 @@ def RunServerMultiThreaded(addr, port, server_handler):
             handler = server_handler(addr, port)
             with http.server.HTTPServer((addr, port), handler, False) as self.httpd:
                 try:
-                    if ipv4_sock and ipv6_sock:
-                        self.httpd.socket = ipv4_sock if self.i < 16 else ipv6_sock
-                    elif ipv6_sock:
-                        self.httpd.socket = ipv6_sock
-                    elif ipv4_sock:
-                        self.httpd.socket = ipv4_sock
-                    else:
-                        print("ERROR: Both IPv4 and IPv6 cannot bind. Server features will not work.")
-                        return
+                    self.httpd.socket = self.server_socket
 
                     self.httpd.server_bind = self.server_close = lambda self: None
                     self.httpd.serve_forever()
@@ -7801,17 +7802,20 @@ def RunServerMultiThreaded(addr, port, server_handler):
             self.httpd.server_close()
 
     threadArr = []
-    for i in range(numThreads):
-        threadArr.append(Thread(i))
+    listener_thread_sockets = _get_listener_thread_sockets(ipv4_sock, ipv6_sock, numThreads)
+    if not listener_thread_sockets:
+        print("ERROR: Both IPv4 and IPv6 cannot bind. Server features will not work.")
+    for server_socket in listener_thread_sockets:
+        threadArr.append(Thread(server_socket))
     while 1:
         try:
             time.sleep(10)
         except (KeyboardInterrupt,SystemExit):
             global exitcounter
             exitcounter = 999
-            for i in range(numThreads):
+            for thread in threadArr:
                 try:
-                    threadArr[i].stop()
+                    thread.stop()
                 except Exception:
                     continue
             sys.exit(0)

--- a/tests/test_http_listeners.py
+++ b/tests/test_http_listeners.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+
+parent_dir = os.path.abspath(os.path.join(__file__, "..", ".."))
+sys.path.append(parent_dir)
+
+import koboldcpp
+
+
+class ListenerThreadSocketTests(unittest.TestCase):
+    def test_each_available_listener_gets_a_full_worker_pool(self):
+        cases = (
+            (True, True, 24, 24),
+            (True, False, 24, 0),
+            (False, True, 0, 24),
+            (False, False, 0, 0),
+        )
+
+        for ipv4_available, ipv6_available, expected_ipv4, expected_ipv6 in cases:
+            with self.subTest(ipv4=ipv4_available, ipv6=ipv6_available):
+                ipv4_sock = object() if ipv4_available else None
+                ipv6_sock = object() if ipv6_available else None
+
+                thread_sockets = koboldcpp._get_listener_thread_sockets(
+                    ipv4_sock, ipv6_sock, 24
+                )
+
+                self.assertEqual(
+                    sum(server_socket is ipv4_sock for server_socket in thread_sockets),
+                    expected_ipv4,
+                )
+                self.assertEqual(
+                    sum(server_socket is ipv6_sock for server_socket in thread_sockets),
+                    expected_ipv6,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

When both IPv4 and IPv6 sockets bind, `RunServerMultiThreaded` partitions its 24 synchronous HTTP handler loops between the address families: 16 receive the IPv4 socket and 8 receive the IPv6 socket. Idle capacity assigned to one family cannot accept requests arriving on the other. In particular, a client resolving `localhost` to `::1` can hit an eight-request frontend ceiling while all IPv4 handlers are idle.

When only one address family binds, it already receives all 24 handlers.

## What this changes

- Gives every successfully bound listener the complete 24-handler pool.
- Passes each handler thread its listener socket explicitly.
- Keeps `IPV6_V6ONLY=1`, existing bind fallback behavior, TLS socket wrapping, daemon-thread behavior, and shutdown cleanup intact.

On a dual-stack host this intentionally changes the frontend total from 24 handler threads to 48: 24 IPv4 plus 24 IPv6. Native inference concurrency, continuous-batching slots, and the request queue remain governed separately and are not increased by this change.

## Validation

- Added a focused unit test covering dual-stack, IPv4-only, IPv6-only, and no-listener allocation.
- `python -B -m unittest tests.test_http_listeners` passes.
- Python AST parsing and `git diff --check` pass.
- Independently reviewed for socket ownership, TLS wrapping, shutdown behavior, and dual-stack overlap.

The unit test exercises allocation directly; it does not stand up a live TLS dual-stack server.
