### PR TITLE
feat: add native continuous batching benchmark

### DIFF
--- a/expose.cpp
+++ b/expose.cpp
@@ -294,6 +294,21 @@ extern "C"
     void batch_generate_release(int request_id) {
         gpttype_batch_generate_release(request_id);
     }
+    batch_benchmark_outputs batch_benchmark(const generation_inputs inputs, int jobs) {
+        try
+        {
+            return gpttype_batch_benchmark(inputs, jobs);
+        }
+        catch(...)
+        {
+            batch_benchmark_outputs output;
+            output.status = BATCH_BENCHMARK_REQUEST_FAILED;
+            output.jobs = jobs;
+            output.failures = jobs > 0 ? jobs : 0;
+            output.first_failure_stopreason = stop_reason::ERROR_ENCOUNTERED;
+            return output;
+        }
+    }
     bool has_audio_support()
     {
         return audio_multimodal_supported;

--- a/expose.h
+++ b/expose.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 const int tensor_split_max = 16;
 const int logprobs_max = 10;
@@ -156,6 +158,43 @@ struct generation_outputs
     int completion_tokens = 0;
     const char * text; //response will now be stored in c++ allocated memory
 };
+enum batch_benchmark_status
+{
+    BATCH_BENCHMARK_SUCCESS = 1,
+    BATCH_BENCHMARK_UNAVAILABLE = -1,
+    BATCH_BENCHMARK_INVALID_CONFIG = -2,
+    BATCH_BENCHMARK_BUSY = -3,
+    BATCH_BENCHMARK_MISSING_REQUEST = -4,
+    BATCH_BENCHMARK_REQUEST_FAILED = -5,
+};
+struct batch_benchmark_outputs
+{
+    int status = BATCH_BENCHMARK_UNAVAILABLE;
+    int jobs = 0;
+    int slots = 0;
+    int successes = 0;
+    int failures = 0;
+    int engine_context = 0;
+    int prompt_tokens_min = 0;
+    int prompt_tokens_max = 0;
+    int first_failure_request = 0;
+    int first_failure_stopreason = stop_reason::INVALID;
+    int64_t total_prompt_tokens = 0;
+    int64_t total_generated_tokens = 0;
+    double wall_seconds = 0.0;
+    double cohort_e2e_generated_tps = 0.0;
+    double requests_per_second = 0.0;
+    double jobs_per_hour = 0.0;
+    double latency_p50_ms = 0.0;
+    double latency_p95_ms = 0.0;
+    double latency_max_ms = 0.0;
+};
+static_assert(std::is_standard_layout<batch_benchmark_outputs>::value, "batch_benchmark_outputs must remain a C-compatible POD layout");
+static_assert(std::is_trivially_copyable<batch_benchmark_outputs>::value, "batch_benchmark_outputs must remain trivially copyable");
+static_assert(sizeof(batch_benchmark_outputs) == 112, "batch_benchmark_outputs ABI size changed");
+static_assert(offsetof(batch_benchmark_outputs, total_prompt_tokens) == 40, "batch_benchmark_outputs integer layout changed");
+static_assert(offsetof(batch_benchmark_outputs, wall_seconds) == 56, "batch_benchmark_outputs timing layout changed");
+static_assert(offsetof(batch_benchmark_outputs, latency_max_ms) == 104, "batch_benchmark_outputs latency layout changed");
 struct token_count_outputs
 {
     int count = 0;
@@ -415,3 +454,4 @@ const char * gpttype_batch_generate_pending_output(int request_id);
 generation_outputs gpttype_batch_generate_result(int request_id);
 bool gpttype_batch_generate_abort(int request_id);
 void gpttype_batch_generate_release(int request_id);
+batch_benchmark_outputs gpttype_batch_benchmark(const generation_inputs inputs, int jobs);

--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -4264,9 +4264,11 @@ struct BatchGenerateRequest
     std::string output;
     int prompt_token_count = 0;
     int completion_token_count = 0;
+    std::chrono::steady_clock::time_point submitted_at;
     std::chrono::steady_clock::time_point start_time;
     std::chrono::steady_clock::time_point process_start_time;
     std::chrono::steady_clock::time_point generation_start_time;
+    std::chrono::steady_clock::time_point finished_at;
     float init_time = 0.0f;
     float process_time = 0.0f;
     stop_reason finish_reason = stop_reason::INVALID;
@@ -4291,6 +4293,7 @@ static std::thread batch_worker_thread;
 static bool batch_worker_stop = false;
 static bool batch_worker_started = false;
 static bool batch_legacy_active = false;
+static bool batch_benchmark_active = false;
 static bool batch_touched_since_legacy = false;
 static int batch_legacy_waiting = 0;
 static int batch_next_request_id = 1;
@@ -4325,13 +4328,8 @@ static bool batch_has_live_locked()
     return false;
 }
 
-static void batch_invalidate_legacy_context_locked()
+static void batch_clear_legacy_context_locked()
 {
-    if(!batch_touched_since_legacy)
-    {
-        return;
-    }
-    batch_touched_since_legacy = false;
     n_past = 0;
     current_context_tokens.clear();
     last_n_tokens.clear();
@@ -4345,6 +4343,16 @@ static void batch_invalidate_legacy_context_locked()
     {
         llama_memory_seq_rm(llama_get_memory(draft_ctx), 0, -1, -1);
     }
+}
+
+static void batch_invalidate_legacy_context_locked()
+{
+    if(!batch_touched_since_legacy)
+    {
+        return;
+    }
+    batch_touched_since_legacy = false;
+    batch_clear_legacy_context_locked();
     if(debugmode==1 && !is_quiet)
     {
         printf("\n[Continuous batching touched shared context; forcing next legacy generation to reprocess prompt]\n");
@@ -4359,7 +4367,7 @@ public:
         std::unique_lock<std::mutex> lock(batch_mutex);
         batch_legacy_waiting++;
         batch_cv.notify_all();
-        batch_cv.wait(lock, [](){ return !batch_legacy_active && !batch_has_live_locked(); });
+        batch_cv.wait(lock, [](){ return !batch_legacy_active && !batch_benchmark_active && !batch_has_live_locked(); });
         batch_legacy_waiting--;
         batch_invalidate_legacy_context_locked();
         batch_legacy_active = true;
@@ -4371,6 +4379,38 @@ public:
         batch_legacy_active = false;
         batch_cv.notify_all();
     }
+};
+
+class BatchBenchmarkGuard
+{
+public:
+    bool try_acquire()
+    {
+        std::lock_guard<std::mutex> lock(batch_mutex);
+        if(batch_benchmark_active || batch_legacy_active || batch_legacy_waiting > 0 || batch_has_live_locked())
+        {
+            return false;
+        }
+        batch_clear_legacy_context_locked();
+        batch_touched_since_legacy = false;
+        batch_benchmark_active = true;
+        acquired = true;
+        return true;
+    }
+
+    ~BatchBenchmarkGuard()
+    {
+        if(!acquired)
+        {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(batch_mutex);
+        batch_benchmark_active = false;
+        batch_cv.notify_all();
+    }
+
+private:
+    bool acquired = false;
 };
 
 static bool batch_inputs_eligible(const generation_inputs & inputs)
@@ -4618,6 +4658,7 @@ static void batch_finish_request_locked(BatchGenerateRequest & req, stop_reason 
     req.result.prompt_tokens = req.prompt_token_count;
     req.result.completion_tokens = req.completion_token_count;
     req.result.text = req.output.c_str();
+    req.finished_at = finish_time;
     req.state = reason == stop_reason::ERROR_ENCOUNTERED ? BatchState::FAILED : (reason == stop_reason::INVALID ? BatchState::ABORTED : BatchState::FINISHED);
     if(req.slot >= 0 && llama_ctx_v4)
     {
@@ -4685,7 +4726,8 @@ static bool batch_claim_waiting_locked()
             TokenizeString(req->prompt_added_memory, added_memory_tokens, file_format, add_bos_token);
         }
 
-        int n_ctx = req->max_context_length > 0 ? std::min(req->max_context_length, kcpp_data->n_ctx) : kcpp_data->n_ctx;
+        const int engine_context = batch_benchmark_active ? max_context_limit_at_load : kcpp_data->n_ctx;
+        int n_ctx = req->max_context_length > 0 ? std::min(req->max_context_length, engine_context) : engine_context;
         AppendDedicatedMemoryAndNegativePrompt(req->prompt_tokens, added_memory_tokens, std::vector<llama_token>(), req->max_length, n_ctx);
 
         if(req->max_length > 0 && (int) req->prompt_tokens.size() + req->max_length > n_ctx)
@@ -4809,12 +4851,26 @@ static void batch_worker_loop()
         std::lock_guard<std::mutex> lock(batch_mutex);
         if(decode_status != 0)
         {
-            for(int request_id : decode_ids)
+            if(batch_benchmark_active)
             {
-                BatchGenerateRequest * req = batch_find_request_locked(request_id);
-                if(req && batch_is_live_state(req->state))
+                batch_waiting.clear();
+                for(auto & req : batch_requests)
                 {
-                    batch_finish_request_locked(*req, stop_reason::ERROR_ENCOUNTERED);
+                    if(req && batch_is_live_state(req->state))
+                    {
+                        batch_finish_request_locked(*req, stop_reason::ERROR_ENCOUNTERED);
+                    }
+                }
+            }
+            else
+            {
+                for(int request_id : decode_ids)
+                {
+                    BatchGenerateRequest * req = batch_find_request_locked(request_id);
+                    if(req && batch_is_live_state(req->state))
+                    {
+                        batch_finish_request_locked(*req, stop_reason::ERROR_ENCOUNTERED);
+                    }
                 }
             }
             continue;
@@ -4880,19 +4936,11 @@ bool gpttype_batch_generate_enabled()
     return continuous_batching_slots > 1 && file_format == FileFormat::GGUF_GENERIC && llama_ctx_v4 && kcpp_data && !draft_ctx && !guidance_ctx;
 }
 
-int gpttype_batch_generate_submit(const generation_inputs inputs)
+static int batch_generate_submit_locked(const generation_inputs & inputs, const std::chrono::steady_clock::time_point & submitted_at)
 {
-    if(!batch_inputs_eligible(inputs))
-    {
-        return -1;
-    }
-    std::lock_guard<std::mutex> lock(batch_mutex);
-    if(batch_legacy_active || batch_legacy_waiting > 0)
-    {
-        return -1;
-    }
     auto req = std::make_unique<BatchGenerateRequest>();
     req->id = batch_next_request_id++;
+    req->submitted_at = submitted_at;
     req->prompt = inputs.prompt ? inputs.prompt : "";
     req->prompt_added_memory = inputs.memory ? inputs.memory : "";
     req->max_context_length = inputs.max_context_length;
@@ -4938,6 +4986,22 @@ int gpttype_batch_generate_submit(const generation_inputs inputs)
     int request_id = req->id;
     batch_requests.emplace_back(std::move(req));
     batch_waiting.push_back(request_id);
+    return request_id;
+}
+
+int gpttype_batch_generate_submit(const generation_inputs inputs)
+{
+    if(!batch_inputs_eligible(inputs))
+    {
+        return -1;
+    }
+    const auto submitted_at = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(batch_mutex);
+    if(batch_benchmark_active || batch_legacy_active || batch_legacy_waiting > 0)
+    {
+        return -1;
+    }
+    int request_id = batch_generate_submit_locked(inputs, submitted_at);
     batch_start_worker_locked();
     batch_cv.notify_all();
     return request_id;
@@ -5021,6 +5085,203 @@ void gpttype_batch_generate_release(int request_id)
         return req && req->id == request_id && !batch_is_live_state(req->state);
     }), batch_requests.end());
     batch_cv.notify_all();
+}
+
+static double batch_benchmark_percentile(std::vector<double> values, double percentile)
+{
+    if(values.empty())
+    {
+        return 0.0;
+    }
+    std::sort(values.begin(), values.end());
+    size_t rank = (size_t) std::ceil(percentile * values.size());
+    rank = std::max((size_t) 1, std::min(rank, values.size()));
+    return values[rank - 1];
+}
+
+batch_benchmark_outputs gpttype_batch_benchmark(const generation_inputs inputs, int jobs)
+{
+    batch_benchmark_outputs output;
+    output.jobs = jobs;
+    output.slots = continuous_batching_slots;
+    output.engine_context = max_context_limit_at_load;
+
+    if(!gpttype_batch_generate_enabled() || !batch_inputs_eligible(inputs))
+    {
+        output.status = BATCH_BENCHMARK_UNAVAILABLE;
+        return output;
+    }
+    const int active_jobs = std::min(jobs, continuous_batching_slots);
+    if(jobs < 1 || jobs > 128 || inputs.max_length < 2 ||
+        inputs.max_context_length <= inputs.max_length ||
+        inputs.max_context_length > output.engine_context ||
+        (int64_t) active_jobs * inputs.max_context_length > output.engine_context)
+    {
+        output.status = BATCH_BENCHMARK_INVALID_CONFIG;
+        return output;
+    }
+
+    BatchBenchmarkGuard benchmark_guard;
+    if(!benchmark_guard.try_acquire())
+    {
+        output.status = BATCH_BENCHMARK_BUSY;
+        return output;
+    }
+
+    const auto cohort_submitted_at = std::chrono::steady_clock::now();
+    std::vector<int> request_ids;
+    std::vector<double> latency_ms;
+    std::vector<BatchGenerateRequest *> requests;
+    try
+    {
+        request_ids.reserve(jobs);
+        latency_ms.reserve(jobs);
+        requests.reserve(jobs);
+    }
+    catch(...)
+    {
+        output.status = BATCH_BENCHMARK_REQUEST_FAILED;
+        output.failures = jobs;
+        output.first_failure_stopreason = stop_reason::ERROR_ENCOUNTERED;
+        return output;
+    }
+    {
+        std::lock_guard<std::mutex> lock(batch_mutex);
+        const size_t previous_request_count = batch_requests.size();
+        const size_t previous_waiting_count = batch_waiting.size();
+        const int previous_next_request_id = batch_next_request_id;
+        try
+        {
+            batch_requests.reserve(previous_request_count + jobs);
+            for(int job = 0; job < jobs; ++job)
+            {
+                request_ids.push_back(batch_generate_submit_locked(inputs, cohort_submitted_at));
+            }
+            batch_start_worker_locked();
+            batch_cv.notify_all();
+        }
+        catch(...)
+        {
+            while(batch_waiting.size() > previous_waiting_count)
+            {
+                batch_waiting.pop_back();
+            }
+            batch_requests.resize(previous_request_count);
+            batch_next_request_id = previous_next_request_id;
+            output.status = BATCH_BENCHMARK_REQUEST_FAILED;
+            output.failures = jobs;
+            output.first_failure_stopreason = stop_reason::ERROR_ENCOUNTERED;
+            return output;
+        }
+    }
+
+    bool missing_request = false;
+    {
+        std::unique_lock<std::mutex> lock(batch_mutex);
+        batch_cv.wait(lock, [](){ return !batch_has_live_locked(); });
+
+        for(int request_id : request_ids)
+        {
+            BatchGenerateRequest * req = batch_find_request_locked(request_id);
+            if(!req)
+            {
+                missing_request = true;
+                continue;
+            }
+            requests.push_back(req);
+        }
+
+        if(!requests.empty())
+        {
+            output.prompt_tokens_min = requests.front()->prompt_token_count;
+            output.prompt_tokens_max = requests.front()->prompt_token_count;
+            auto cohort_finished_at = requests.front()->finished_at;
+            for(const BatchGenerateRequest * req : requests)
+            {
+                output.prompt_tokens_min = std::min(output.prompt_tokens_min, req->prompt_token_count);
+                output.prompt_tokens_max = std::max(output.prompt_tokens_max, req->prompt_token_count);
+                output.total_prompt_tokens += req->prompt_token_count;
+                output.total_generated_tokens += req->completion_token_count;
+                cohort_finished_at = std::max(cohort_finished_at, req->finished_at);
+                if(req->submitted_at.time_since_epoch().count() != 0 && req->finished_at >= req->submitted_at)
+                {
+                    const double request_latency_ms = std::chrono::duration<double, std::milli>(req->finished_at - req->submitted_at).count();
+                    if(std::isfinite(request_latency_ms))
+                    {
+                        latency_ms.push_back(request_latency_ms);
+                    }
+                }
+            }
+
+            const int expected_prompt_tokens = inputs.max_context_length - inputs.max_length;
+            const bool prompt_counts_valid =
+                output.prompt_tokens_min == output.prompt_tokens_max &&
+                output.prompt_tokens_min > 0 &&
+                (output.prompt_tokens_min == expected_prompt_tokens ||
+                 output.prompt_tokens_min == expected_prompt_tokens - 1);
+            for(const BatchGenerateRequest * req : requests)
+            {
+                const bool request_valid = prompt_counts_valid &&
+                    req->result.status == 1 &&
+                    req->finish_reason == stop_reason::OUT_OF_TOKENS &&
+                    req->completion_token_count == inputs.max_length;
+                if(request_valid)
+                {
+                    output.successes++;
+                }
+                else
+                {
+                    output.failures++;
+                    if(output.first_failure_request == 0)
+                    {
+                        output.first_failure_request = req->id;
+                        output.first_failure_stopreason = req->finish_reason;
+                    }
+                }
+            }
+
+            if(cohort_finished_at >= cohort_submitted_at)
+            {
+                output.wall_seconds = std::chrono::duration<double>(cohort_finished_at - cohort_submitted_at).count();
+            }
+        }
+
+        batch_requests.erase(std::remove_if(batch_requests.begin(), batch_requests.end(), [&request_ids](const std::unique_ptr<BatchGenerateRequest> & req){
+            return req && std::find(request_ids.begin(), request_ids.end(), req->id) != request_ids.end();
+        }), batch_requests.end());
+        batch_cv.notify_all();
+    }
+
+    if(missing_request || output.successes + output.failures != jobs)
+    {
+        output.status = BATCH_BENCHMARK_MISSING_REQUEST;
+        output.failures = jobs - output.successes;
+        return output;
+    }
+    const bool timing_valid = output.wall_seconds > 0.0 && std::isfinite(output.wall_seconds) && latency_ms.size() == (size_t) jobs;
+    if(timing_valid)
+    {
+        output.cohort_e2e_generated_tps = (double) output.total_generated_tokens / output.wall_seconds;
+        output.requests_per_second = (double) output.successes / output.wall_seconds;
+        output.jobs_per_hour = output.requests_per_second * 3600.0;
+    }
+    output.latency_p50_ms = batch_benchmark_percentile(latency_ms, 0.50);
+    output.latency_p95_ms = batch_benchmark_percentile(latency_ms, 0.95);
+    output.latency_max_ms = latency_ms.empty() ? 0.0 : *std::max_element(latency_ms.begin(), latency_ms.end());
+    const bool metrics_valid = timing_valid &&
+        output.cohort_e2e_generated_tps > 0.0 && std::isfinite(output.cohort_e2e_generated_tps) &&
+        output.requests_per_second > 0.0 && std::isfinite(output.requests_per_second) &&
+        output.jobs_per_hour > 0.0 && std::isfinite(output.jobs_per_hour) &&
+        std::isfinite(output.latency_p50_ms) && std::isfinite(output.latency_p95_ms) && std::isfinite(output.latency_max_ms);
+    if(output.failures == 0 && !metrics_valid)
+    {
+        output.successes = 0;
+        output.failures = jobs;
+        output.first_failure_request = request_ids.empty() ? 0 : request_ids.front();
+        output.first_failure_stopreason = stop_reason::INVALID;
+    }
+    output.status = output.failures == 0 && metrics_valid ? BATCH_BENCHMARK_SUCCESS : BATCH_BENCHMARK_REQUEST_FAILED;
+    return output;
 }
 
 std::string gpttype_get_chat_template()

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -86,6 +86,15 @@ global_memory = {"tunnel_url": "", "restart_target":"", "input_to_exit":False, "
 using_gui_launcher = False
 
 handle = None
+_BATCH_BENCHMARK_SENTINEL = object()
+BATCH_BENCHMARK_STATUS_NAMES = {
+    1: "success",
+    -1: "continuous_batching_unavailable",
+    -2: "invalid_configuration",
+    -3: "scheduler_busy",
+    -4: "request_missing",
+    -5: "request_failed",
+}
 friendlymodelname = "inactive"
 friendlysdmodelname = "inactive"
 friendlyembeddingsmodelname = "inactive"
@@ -375,6 +384,27 @@ class generation_outputs(ctypes.Structure):
                 ("prompt_tokens", ctypes.c_int),
                 ("completion_tokens", ctypes.c_int),
                 ("text", ctypes.c_char_p)]
+
+class batch_benchmark_outputs(ctypes.Structure):
+    _fields_ = [("status", ctypes.c_int),
+                ("jobs", ctypes.c_int),
+                ("slots", ctypes.c_int),
+                ("successes", ctypes.c_int),
+                ("failures", ctypes.c_int),
+                ("engine_context", ctypes.c_int),
+                ("prompt_tokens_min", ctypes.c_int),
+                ("prompt_tokens_max", ctypes.c_int),
+                ("first_failure_request", ctypes.c_int),
+                ("first_failure_stopreason", ctypes.c_int),
+                ("total_prompt_tokens", ctypes.c_int64),
+                ("total_generated_tokens", ctypes.c_int64),
+                ("wall_seconds", ctypes.c_double),
+                ("cohort_e2e_generated_tps", ctypes.c_double),
+                ("requests_per_second", ctypes.c_double),
+                ("jobs_per_hour", ctypes.c_double),
+                ("latency_p50_ms", ctypes.c_double),
+                ("latency_p95_ms", ctypes.c_double),
+                ("latency_max_ms", ctypes.c_double)]
 
 class sd_load_model_inputs(ctypes.Structure):
     _fields_ = [("model_filename", ctypes.c_char_p),
@@ -954,6 +984,8 @@ def init_library():
     handle.batch_generate_abort.restype = ctypes.c_bool
     handle.batch_generate_release.argtypes = [ctypes.c_int]
     handle.batch_generate_release.restype = None
+    handle.batch_benchmark.argtypes = [generation_inputs, ctypes.c_int]
+    handle.batch_benchmark.restype = batch_benchmark_outputs
     handle.has_audio_support.restype = ctypes.c_bool
     handle.has_vision_support.restype = ctypes.c_bool
     handle.get_last_eval_time.restype = ctypes.c_float
@@ -2095,6 +2127,151 @@ def coerce_ban_list(value):
             pass
     return [value]
 
+def batch_benchmark_output_to_dict(output):
+    return {name: getattr(output, name) for name, _ in batch_benchmark_outputs._fields_}
+
+def resolve_batched_benchmark_workload(engine_context, slots, jobs, context_per_job, output_tokens):
+    engine_context = int(engine_context)
+    slots = int(slots)
+    jobs = slots if int(jobs) <= 0 else int(jobs)
+    context_per_job = int(context_per_job)
+    output_tokens = int(output_tokens)
+
+    if engine_context <= 0:
+        raise ValueError("The loaded context size must be positive.")
+    if slots < 2:
+        raise ValueError("Batched benchmark requires --parallelrequests of at least 2.")
+    if jobs < 1 or jobs > 128:
+        raise ValueError("Batched benchmark jobs must be within [1, 128].")
+
+    active_jobs = min(jobs, slots)
+    if context_per_job <= 0:
+        context_per_job = engine_context // active_jobs
+    if context_per_job <= 0:
+        raise ValueError("Per-job benchmark context must be positive.")
+    if context_per_job * active_jobs > engine_context:
+        raise ValueError(
+            f"{active_jobs} active jobs at {context_per_job} tokens require "
+            f"{context_per_job * active_jobs} shared context tokens; only {engine_context} are loaded.")
+    if output_tokens < 2:
+        raise ValueError("Batched benchmark output must be at least 2 tokens.")
+
+    minimum_prompt_tokens = max(min(context_per_job - 4, 16), int(context_per_job * 0.2))
+    maximum_exact_output = context_per_job - minimum_prompt_tokens - 1
+    if output_tokens > maximum_exact_output:
+        raise ValueError(
+            f"Batched benchmark output {output_tokens} is too large for the "
+            f"{context_per_job}-token per-job context (maximum {maximum_exact_output}).")
+
+    return {
+        "engine_context": engine_context,
+        "slots": slots,
+        "jobs": jobs,
+        "active_jobs": active_jobs,
+        "context_per_job": context_per_job,
+        "output_tokens": output_tokens,
+    }
+
+def build_batched_benchmark_prompt(minimum_tokens):
+    repetitions = max(1, int(minimum_tokens)) + 128
+    for _ in range(6):
+        prompt = (" 1" * repetitions) + "\nKCPP_BATCH_BENCHMARK_PROMPT_END\n"
+        if len(tokenize_ids(prompt, False)) > minimum_tokens:
+            return prompt
+        repetitions *= 2
+    raise RuntimeError(f"Could not construct a prompt longer than {minimum_tokens} tokens.")
+
+def run_batched_benchmark(workload):
+    genparams = {
+        "prompt": build_batched_benchmark_prompt(workload["context_per_job"]),
+        "max_length": workload["output_tokens"],
+        "max_context_length": workload["context_per_job"],
+        "temperature": 0.0,
+        "top_k": 0,
+        "top_a": 0.0,
+        "top_p": 1.0,
+        "min_p": 0.0,
+        "typical": 1.0,
+        "tfs": 1.0,
+        "nsigma": 0.0,
+        "rep_pen": 1.0,
+        "rep_pen_range": 0,
+        "presence_penalty": 0.0,
+        "mirostat": 0,
+        "xtc_probability": 0.0,
+        "dynatemp_range": 0.0,
+        "smoothing_factor": 0.0,
+        "adaptive_target": -1.0,
+        "dry_multiplier": 0.0,
+        "sampler_order": [],
+        "stop_sequence": [],
+        "ban_eos_token": True,
+        "bypass_eos": False,
+        "grammar": "",
+        "trim_stop": False,
+        "_batch_benchmark": {
+            "_sentinel": _BATCH_BENCHMARK_SENTINEL,
+            "jobs": workload["jobs"],
+        },
+    }
+    result = generate(genparams=genparams)
+    if "_batch_benchmark" not in result:
+        raise RuntimeError("Native batched benchmark did not return a result.")
+    return result["_batch_benchmark"]
+
+def batched_benchmark_config_snapshot(launch_args, engine_context):
+    return {
+        "batch_size": launch_args.batchsize,
+        "blas_threads": launch_args.blasthreads,
+        "context_size": int(engine_context),
+        "device_override": launch_args.device,
+        "flash_attention": not launch_args.noflashattention,
+        "gpu_layers": "autofit" if launch_args.autofit else launch_args.gpulayers,
+        "main_gpu": launch_args.maingpu,
+        "mmap": launch_args.usemmap,
+        "mlock": launch_args.usemlock,
+        "mmq": not launch_args.nommq,
+        "parallel_requests": launch_args.parallelrequests,
+        "pipeline_parallel": not launch_args.nopipelineparallel,
+        "quant_kv": launch_args.quantkv,
+        "split_mode": launch_args.splitmode,
+        "tensor_split": list(launch_args.tensor_split or []),
+        "threads": launch_args.threads,
+    }
+
+def format_batched_benchmark_lines(summary, workload):
+    status = int(summary["status"])
+    status_name = BATCH_BENCHMARK_STATUS_NAMES.get(status, "unknown_error")
+    reported_slots = max(1, int(summary["slots"] or workload["slots"]))
+    lines = [
+        f"[BATCHBENCH] status={'PASS' if status == 1 else 'FAIL'} code={status} reason={status_name}",
+        (f"[BATCHBENCH] jobs={summary['jobs']} slots={summary['slots']} "
+         f"active_limit={workload['active_jobs']} "
+         f"overflow_jobs={max(0, summary['jobs'] - reported_slots)} "
+         f"minimum_waves={math.ceil(summary['jobs'] / reported_slots)}"),
+        (f"[BATCHBENCH] engine_context={summary['engine_context']} "
+         f"context_per_job={workload['context_per_job']} "
+         f"output_tokens_per_job={workload['output_tokens']}"),
+        (f"[BATCHBENCH] successes={summary['successes']} failures={summary['failures']} "
+         f"prompt_tokens_min={summary['prompt_tokens_min']} prompt_tokens_max={summary['prompt_tokens_max']} "
+         f"total_prompt_tokens={summary['total_prompt_tokens']} "
+         f"total_generated_tokens={summary['total_generated_tokens']}"),
+        (f"[BATCHBENCH] wall_seconds={summary['wall_seconds']:.3f} "
+         f"cohort_e2e_generated_tps={summary['cohort_e2e_generated_tps']:.2f} "
+         f"requests_per_second={summary['requests_per_second']:.4f} "
+         f"jobs_per_hour={summary['jobs_per_hour']:.2f}"),
+        (f"[BATCHBENCH] latency_p50_ms={summary['latency_p50_ms']:.2f} "
+         f"latency_p95_ms={summary['latency_p95_ms']:.2f} "
+         f"latency_max_ms={summary['latency_max_ms']:.2f}"),
+        "[BATCHBENCH] pp_tg_source=BatchRequest_lines native_per_request_queue_included=false cohort_latency_queue_included=true",
+        "[BATCHBENCH] scope=native_scheduler excludes=http_sse_horde_network",
+    ]
+    if status != 1:
+        lines.append(
+            f"[BATCHBENCH] first_failure_request={summary['first_failure_request']} "
+            f"first_failure_stopreason={summary['first_failure_stopreason']}")
+    return lines
+
 def generate(genparams, stream_flag=False):
     global maxctx, args, currentusergenkey, totalgens, pendingabortkey
     default_adapter = {} if chatcompl_adapter is None else chatcompl_adapter
@@ -2330,6 +2507,20 @@ def generate(genparams, stream_flag=False):
         inputs.banned_tokens[n] = tok.encode("UTF-8")
 
     inputs.reasoning_budget = reasoning_budget
+
+    benchmark_config = genparams.get("_batch_benchmark")
+    if (isinstance(benchmark_config, dict)
+            and benchmark_config.get("_sentinel") is _BATCH_BENCHMARK_SENTINEL):
+        benchmark_output = handle.batch_benchmark(inputs, int(benchmark_config["jobs"]))
+        benchmark_result = batch_benchmark_output_to_dict(benchmark_output)
+        return {
+            "text": "",
+            "status": benchmark_result["status"],
+            "stopreason": benchmark_result["first_failure_stopreason"],
+            "prompt_tokens": benchmark_result["prompt_tokens_max"],
+            "completion_tokens": 0,
+            "_batch_benchmark": benchmark_result,
+        }
 
     currentusergenkey = genkey
     totalgens += 1
@@ -11067,6 +11258,27 @@ def main(launch_args, default_args):
         if dlfile:
             args.model_param = dlfile
         load_config_cli(args.model_param)
+        args = convert_invalid_args(args)
+
+    if args.benchmark_batched is not None:
+        if args.benchmark is None:
+            exit_with_error(1, "Error: --benchmark-batched must be combined with --benchmark")
+        if args.benchmark != "stdout":
+            exit_with_error(1, "Error: native batched benchmark currently writes to the console only; omit the benchmark filename")
+        if args.parallelrequests < 2:
+            exit_with_error(1, "Error: --benchmark-batched requires --parallelrequests of at least 2")
+        if args.prompt:
+            exit_with_error(1, "Error: --prompt cannot be combined with --benchmark-batched; the benchmark builds an exact synthetic prompt")
+        incompatible = [name for name, enabled in (
+            ("--smartcache", args.smartcache), ("--smartcontext", args.smartcontext),
+            ("--draftmodel", args.draftmodel), ("--usemtp", args.usemtp),
+            ("--enableguidance", args.enableguidance)) if enabled]
+        if incompatible:
+            exit_with_error(1, f"Error: --benchmark-batched is incompatible with {', '.join(incompatible)}")
+    elif args.benchmark_context:
+        exit_with_error(1, "Error: --benchmark-context requires --benchmark-batched")
+    elif args.benchmark and args.parallelrequests > 1:
+        exit_with_error(1, "Error: legacy --benchmark timing is not valid with --parallelrequests; add --benchmark-batched or use --parallelrequests 1")
 
     if args.exportconfig:
         save_config_cli(args.exportconfig,False)
@@ -12301,6 +12513,41 @@ def kcpp_main_process(launch_args, g_memory=None, gui_launcher=False):
                 else:
                     print("(No Response Received)\n", flush=True)
         else:
+            if args.benchmark_batched is not None:
+                benchlen = args.genlimit if args.genlimit > 0 else 100
+                try:
+                    workload = resolve_batched_benchmark_workload(
+                        maxctx, args.parallelrequests, args.benchmark_batched,
+                        args.benchmark_context, benchlen)
+                except ValueError as ex:
+                    exit_with_error(1, f"Error: {ex}")
+                if not handle.batch_generate_enabled():
+                    exit_with_error(1, "Error: the loaded backend does not support continuous batching")
+
+                benchmodel = sanitize_string(os.path.splitext(os.path.basename(modelname))[0])
+                print(f"\nRunning native batched benchmark - v{KcppVersion}...")
+                print(f"Backend: {libname}")
+                print(f"Layers: {args.gpulayers if not args.autofit else 'Autofit'}")
+                print(f"Model: {benchmodel}")
+                print(f"Timestamp: {datetime.now(timezone.utc).isoformat()}")
+                print("RequestedConfig: " + json.dumps(
+                    batched_benchmark_config_snapshot(args, maxctx),
+                    sort_keys=True, separators=(",", ":")))
+                print("Per-request PP/TG timings will appear in the native BatchRequest lines.")
+                try:
+                    summary = run_batched_benchmark(workload)
+                except RuntimeError as ex:
+                    exit_with_error(1, f"Native batched benchmark could not start: {ex}")
+                print("\nNative Batched Benchmark Completed\n======")
+                for line in format_batched_benchmark_lines(summary, workload):
+                    print(line)
+                if int(summary["status"]) != 1:
+                    exit_with_error(1, "Native batched benchmark failed; see the status and failure lines above.")
+                if global_memory and using_gui_launcher:
+                    global_memory["input_to_exit"] = True
+                    time.sleep(1)
+                return
+
             save_to_file = (args.benchmark and args.benchmark!="stdout" and args.benchmark!="")
             benchmaxctx = maxctx
             benchlen = args.genlimit if args.genlimit > 0 else 100
@@ -12431,6 +12678,8 @@ if __name__ == '__main__':
     advparser.add_argument("--autofitpadding", metavar=('[padding in MB]'), help="How much spare allowance in MB should autofit reserve? If it's too little, the load might fail.", type=int, default=default_autofit_padding)
     advparser.add_argument("--batchsize","--blasbatchsize","--batch-size","-b", help="Sets the batch size used in batched processing (default 512). Setting it to -1 disables batched mode, but keeps other benefits like GPU offload.", type=int,choices=[-1,16,32,64,128,256,512,1024,2048,4096], default=512)
     advparser.add_argument("--benchmark", help="Do not start server, instead run benchmarks. If filename is provided, appends results to provided file.", metavar=('[filename]'), nargs='?', const="stdout", type=str, default=None)
+    advparser.add_argument("--benchmark-batched", help="Run --benchmark as one native continuous-batching cohort. Optionally sets the number of jobs; defaults to --parallelrequests. Jobs above the slot count test native queue overflow.", metavar=('[jobs]'), nargs='?', const=0, type=check_range(int,1,128), default=None)
+    advparser.add_argument("--benchmark-context", help="Total context per batched benchmark job. Defaults to loaded context divided across active jobs.", metavar=('[tokens]'), type=check_range(int,1,524288), default=0)
     advparser.add_argument("--blasthreads","--batchthreads","--threadsbatch","--threads-batch", help="Use a different number of threads during batching if specified. Otherwise, has the same value as --threads",metavar=('[threads]'), type=int, default=0)
     advparser.add_argument("--chatcompletionsadapter", metavar=('[filename]'), help="Select an optional ChatCompletions Adapter JSON file to force custom instruct tags.", default="AutoGuess")
     advparser.add_argument("--cli", help="Does not launch KoboldCpp HTTP server. Instead, enables KoboldCpp from the command line, accepting interactive console input and displaying responses to the terminal.", action='store_true')

--- a/tests/test_batched_benchmark.py
+++ b/tests/test_batched_benchmark.py
@@ -1,0 +1,198 @@
+import ctypes
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+parent_dir = os.path.abspath(os.path.join(__file__, "..", ".."))
+sys.path.append(parent_dir)
+
+import koboldcpp
+
+
+EXPECTED_OUTPUT_FIELDS = (
+    "status",
+    "jobs",
+    "slots",
+    "successes",
+    "failures",
+    "engine_context",
+    "prompt_tokens_min",
+    "prompt_tokens_max",
+    "first_failure_request",
+    "first_failure_stopreason",
+    "total_prompt_tokens",
+    "total_generated_tokens",
+    "wall_seconds",
+    "cohort_e2e_generated_tps",
+    "requests_per_second",
+    "jobs_per_hour",
+    "latency_p50_ms",
+    "latency_p95_ms",
+    "latency_max_ms",
+)
+
+
+class BatchedBenchmarkABITests(unittest.TestCase):
+    def test_ctypes_output_layout_is_fixed(self):
+        self.assertEqual(
+            tuple(name for name, _ in koboldcpp.batch_benchmark_outputs._fields_),
+            EXPECTED_OUTPUT_FIELDS,
+        )
+        self.assertEqual(
+            tuple(field_type for _, field_type in koboldcpp.batch_benchmark_outputs._fields_),
+            (ctypes.c_int,) * 10 + (ctypes.c_int64,) * 2 + (ctypes.c_double,) * 7,
+        )
+        self.assertEqual(ctypes.sizeof(koboldcpp.batch_benchmark_outputs), 112)
+        self.assertEqual(
+            tuple(getattr(koboldcpp.batch_benchmark_outputs, name).offset for name in EXPECTED_OUTPUT_FIELDS),
+            tuple(range(0, 40, 4)) + (40, 48) + tuple(range(56, 112, 8)),
+        )
+
+    def test_private_generate_path_calls_native_runner_once(self):
+        captured = {"calls": 0}
+
+        class FakeHandle:
+            def batch_benchmark(self, generation, jobs):
+                captured.update(
+                    calls=captured["calls"] + 1,
+                    generation_type=type(generation),
+                    prompt=generation.prompt,
+                    max_context_length=generation.max_context_length,
+                    max_length=generation.max_length,
+                    temperature=generation.temperature,
+                    allow_eos_token=generation.allow_eos_token,
+                    sampler_len=generation.sampler_len,
+                    jobs=jobs,
+                )
+                output = koboldcpp.batch_benchmark_outputs()
+                output.status = 1
+                output.jobs = jobs
+                output.prompt_tokens_max = 7680
+                return output
+
+        params = {
+            "prompt": "overlong prompt",
+            "max_context_length": 8192,
+            "max_length": 512,
+            "temperature": 0.0,
+            "top_k": 0,
+            "top_p": 1.0,
+            "sampler_order": [],
+            "ban_eos_token": True,
+            "_batch_benchmark": {
+                "_sentinel": koboldcpp._BATCH_BENCHMARK_SENTINEL,
+                "jobs": 8,
+            },
+        }
+        fake_args = types.SimpleNamespace(defaultgenamt=100, genlimit=0)
+        with mock.patch.object(koboldcpp, "args", fake_args), \
+                mock.patch.object(koboldcpp, "maxctx", 40960), \
+                mock.patch.object(koboldcpp, "handle", FakeHandle()):
+            result = koboldcpp.generate(params)
+
+        self.assertEqual(result["status"], 1)
+        self.assertEqual(captured["calls"], 1)
+        self.assertIs(captured["generation_type"], koboldcpp.generation_inputs)
+        self.assertEqual(captured["prompt"], b"overlong prompt")
+        self.assertEqual(captured["max_context_length"], 8192)
+        self.assertEqual(captured["max_length"], 512)
+        self.assertEqual(captured["temperature"], 0.0)
+        self.assertFalse(captured["allow_eos_token"])
+        self.assertEqual(captured["sampler_len"], 0)
+        self.assertEqual(captured["jobs"], 8)
+
+
+class BatchedBenchmarkWorkloadTests(unittest.TestCase):
+    def test_bare_batched_flag_defaults_jobs_to_slots(self):
+        workload = koboldcpp.resolve_batched_benchmark_workload(40960, 4, 0, 0, 512)
+        self.assertEqual(workload["jobs"], 4)
+
+    def test_default_context_uses_active_slots(self):
+        workload = koboldcpp.resolve_batched_benchmark_workload(40960, 4, 8, 0, 512)
+        self.assertEqual(workload["active_jobs"], 4)
+        self.assertEqual(workload["context_per_job"], 10240)
+
+    def test_jobs_below_slots_only_reserve_jobs(self):
+        workload = koboldcpp.resolve_batched_benchmark_workload(40960, 20, 4, 0, 512)
+        self.assertEqual(workload["active_jobs"], 4)
+        self.assertEqual(workload["context_per_job"], 10240)
+
+    def test_explicit_context_cannot_overcommit_active_slots(self):
+        with self.assertRaisesRegex(ValueError, "shared context"):
+            koboldcpp.resolve_batched_benchmark_workload(40960, 4, 8, 12000, 512)
+
+    def test_output_must_fit_without_generate_clamping(self):
+        with self.assertRaisesRegex(ValueError, "too large"):
+            koboldcpp.resolve_batched_benchmark_workload(1024, 2, 2, 512, 450)
+
+    def test_prompt_builder_grows_until_token_count_exceeds_context(self):
+        with mock.patch.object(koboldcpp, "tokenize_ids", side_effect=lambda prompt, _special: range(prompt.count(" 1") // 4)):
+            prompt = koboldcpp.build_batched_benchmark_prompt(512)
+        self.assertGreater(prompt.count(" 1") // 4, 512)
+
+
+class BatchedBenchmarkReportingTests(unittest.TestCase):
+    def make_summary(self, status=1):
+        summary = {
+            name: (0.0 if field_type is ctypes.c_double else 0)
+            for name, field_type in koboldcpp.batch_benchmark_outputs._fields_
+        }
+        summary.update(
+            status=status,
+            jobs=8,
+            slots=4,
+            successes=8 if status == 1 else 7,
+            failures=0 if status == 1 else 1,
+            engine_context=40960,
+            prompt_tokens_min=9940,
+            prompt_tokens_max=9940,
+            total_prompt_tokens=79520,
+            total_generated_tokens=2400,
+            wall_seconds=10.0,
+            cohort_e2e_generated_tps=240.0,
+            requests_per_second=0.8,
+            jobs_per_hour=2880.0,
+            latency_p50_ms=5000.0,
+            latency_p95_ms=10000.0,
+            latency_max_ms=10000.0,
+        )
+        return summary
+
+    def test_success_output_describes_native_scope_and_overflow(self):
+        workload = koboldcpp.resolve_batched_benchmark_workload(40960, 4, 8, 10240, 300)
+        lines = koboldcpp.format_batched_benchmark_lines(self.make_summary(), workload)
+        output = "\n".join(lines)
+        self.assertIn("status=PASS", output)
+        self.assertIn("overflow_jobs=4", output)
+        self.assertIn("minimum_waves=2", output)
+        self.assertIn("pp_tg_source=BatchRequest_lines", output)
+        self.assertIn("cohort_latency_queue_included=true", output)
+
+    def test_failure_output_includes_native_request_and_stop_reason(self):
+        workload = koboldcpp.resolve_batched_benchmark_workload(40960, 4, 8, 10240, 300)
+        summary = self.make_summary(status=-5)
+        summary["first_failure_request"] = 42
+        summary["first_failure_stopreason"] = -2
+        output = "\n".join(koboldcpp.format_batched_benchmark_lines(summary, workload))
+        self.assertIn("status=FAIL code=-5 reason=request_failed", output)
+        self.assertIn("first_failure_request=42", output)
+        self.assertIn("first_failure_stopreason=-2", output)
+
+    def test_config_snapshot_is_reproducible_and_omits_credentials(self):
+        launch_args = types.SimpleNamespace(
+            batchsize=512, blasthreads=8, device="CUDA0", noflashattention=False,
+            autofit=False, gpulayers=99, maingpu=0, usemmap=True, usemlock=False,
+            nommq=True, parallelrequests=4, nopipelineparallel=False, quantkv="q8_0",
+            splitmode="layer", tensor_split=[1.0], threads=12, password="secret")
+        snapshot = koboldcpp.batched_benchmark_config_snapshot(launch_args, 40960)
+        self.assertEqual(snapshot["context_size"], 40960)
+        self.assertEqual(snapshot["parallel_requests"], 4)
+        self.assertFalse(snapshot["mmq"])
+        self.assertNotIn("password", snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> [!NOTE]
> This remains a draft until it has had a loaded-model smoke test.

## Summary

Adds a continuous-batching benchmark whose execution core is native C++. Python is limited to CLI validation, normal `generation_inputs` marshalling through ctypes, synthetic prompt construction, and console formatting.

The native runner:

- submits the whole cohort atomically into KoboldCpp's existing continuous-batching scheduler;
- uses the existing slot assignment and waiting queue, so jobs above `--parallelrequests` exercise real overflow waves;
- owns benchmark exclusivity against normal batch and legacy generation, and clears residual legacy sequence-0 KV before measuring;
- waits and aggregates in C++, including queue-inclusive cohort latency and throughput;
- rolls back partial submission on allocation/start failure and fails the full cohort on native decode errors;
- validates identical exact-size prompts, exact completion counts, and complete finite timing data before reporting PASS.

There is no second scheduler or parallel Python request runner. The existing native `BatchRequest` lines from `20e5b61` remain the source of per-request PP/TG timings.

## Output

The console reports:

- jobs, native slots, overflow jobs, and minimum waves;
- engine and per-job context, prompt-token range, and total prompt/generated tokens;
- cohort end-to-end generated tokens/s, requests/s, and jobs/hour;
- queue-inclusive end-to-end latency p50/p95/max;
- native status/failure details and a curated non-secret snapshot of requested launch settings.

Metric-scope lines state that `BatchRequest` PP/TG excludes native queue time, cohort latency includes it, and HTTP/SSE/Horde/network overhead is outside this benchmark.

## CLI

```text
koboldcpp.exe model.gguf --benchmark --benchmark-batched 8 \
  --parallelrequests 4 --contextsize 40960 --benchmark-context 10240 \
  --genlimit 300
```

With four slots and eight jobs, this runs two native queue waves. A bare `--benchmark-batched` defaults jobs to the slot count. Omitting `--benchmark-context` divides loaded context across the jobs that can be active concurrently.

The synthetic benchmark alone uses deterministic greedy sampling and bans EOS. It does not normalize or override sampler settings for API or Horde generations.

Legacy `--benchmark` with `--parallelrequests > 1` is rejected with guidance to add `--benchmark-batched`: the legacy path launches only one request and reads legacy timing globals, so its result is not a valid concurrent-batching measurement.

## Validation

- 11 focused Python tests pass, covering the 112-byte native ABI, private one-call dispatch, workload/overflow sizing, exact prompt construction, reporting, failure output, and requested-config redaction.
- C++17 syntax checks pass for the modified native translation units in both CPU and CUDA configurations.
- C++ standard-layout, trivially-copyable, size, and key-offset assertions mirror the ctypes checks.
- `git diff --check` and CLI help checks pass.
- Independent concurrency and maintainability re-audits found no remaining blocker.

A loaded-model runtime smoke is still outstanding, so the PR remains a draft.