### PR TITLE
fix(gui): preserve disabled VAE tiling in configs

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -9940,7 +9940,7 @@ def show_gui():
         sd_photomaker_var.set(mydict["sdphotomaker"] if ("sdphotomaker" in mydict and mydict["sdphotomaker"]) else "")
         sd_upscaler_var.set(mydict["sdupscaler"] if ("sdupscaler" in mydict and mydict["sdupscaler"]) else "")
         sd_vaeauto_var.set(1 if ("sdvaeauto" in mydict and mydict["sdvaeauto"]) else 0)
-        sd_tiled_vae_var.set(str(mydict["sdtiledvae"]) if ("sdtiledvae" in mydict and mydict["sdtiledvae"]) else str(default_vae_tile_threshold))
+        sd_tiled_vae_var.set(str(mydict["sdtiledvae"]) if "sdtiledvae" in mydict else str(default_vae_tile_threshold))
         sdl_sanitized = sanitize_lora_list(mydict.get('sdlora'))
         sd_lora_var.set("|".join(sdl_sanitized))
         sd_loramult_var.set(" ".join(f"{n:.3f}".rstrip('0').rstrip('.') for n in mydict.get("sdloramult", [])))


### PR DESCRIPTION
## Summary

- preserve a saved `sdtiledvae: 0` when loading a `.kcpps` file in the launcher
- fall back to the default threshold only when the key is absent

This addresses the VAE tiling threshold reload bug in #2065. Zero is the documented value for disabling VAE tiling, but the previous truthiness check replaced it with the default.

## Verification

- `koboldcpp.py` syntax compilation passes
- exact config expression tested with saved `0`, saved `768`, and a missing key
- `git diff --check` passes

The existing `tests/test_koboldcpp.py` doctest still has one unrelated warning-text expectation failure on current `concedo_experimental`.