### PR TITLE
Fix Generate More/Submit button dead when a stale voice_typing_mode is loaded without Whisper

### DIFF
--- a/embd_res/klite.embd
+++ b/embd_res/klite.embd
@@ -19685,7 +19685,7 @@ Current version indicated by LITEVER below.
 	}
 	function submit_generation_button(aesthetic_ui)
 	{
-		if(localsettings.voice_typing_mode==0) //only when voice is off
+		if(localsettings.voice_typing_mode==0 || !is_using_kcpp_with_whisper()) //normal submit when voice off, or when whisper is unavailable (e.g. stale saved setting) so the button still works
 		{
 			if(aesthetic_ui)
 			{


### PR DESCRIPTION
### Summary
Fixes #2353.

When a session has `voice_typing_mode > 0` (a "Voice Input" mode selected) and is then reopened **without** a Whisper model loaded, the Voice Input dropdown is greyed out and cannot be reset by the user. In that state the **Generate More** / **Submit** button stops working.

### Root cause
The Submit button wires both `onclick="submit_generation_button(...)"` and `onpointerdown/up="ptt_start()/ptt_end()"`. `submit_generation_button()` only performs a normal generation when `voice_typing_mode == 0`:

```js
function submit_generation_button(aesthetic_ui)
{
    if(localsettings.voice_typing_mode==0) //only when voice is off
    {
        ...prepare_submit_generation()...
    }
}
```

With a stale saved `voice_typing_mode > 0` but no Whisper backend, the voice path can never fire (`ready_to_record()` requires Whisper), and the `onclick` branch is skipped — so pressing the button does nothing.

### Fix
Guard the branch with `is_using_kcpp_with_whisper()`, matching the exact pattern already used everywhere else `voice_typing_mode` is checked (`toggled_voicetyping`, `update_submit_button` rendering, `ready_to_record`, init). When Whisper is unavailable the button now falls back to normal generation regardless of the stale saved setting. Behaviour is unchanged when Whisper is loaded.

One line changed in `embd_res/klite.embd`.

### Test plan
1. Load Kobold with a Whisper model, enable a Voice Input mode, close.
2. Relaunch **without** the Whisper model.
3. Voice Input remains selected/greyed — but **Generate More / Submit now works** (previously dead).
4. With Whisper loaded, voice recording still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
