### PR TITLE
docs: fix `--blasbatchssize` typo in README (should be `--blasbatchsize`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Finally, obtain and load a GGUF model. See [here](#Obtaining-a-GGUF-model)
 - **GPU Acceleration**: If you're on Windows with an Nvidia GPU you can get CUDA support out of the box using the `--usecuda`  flag (Nvidia Only), or `--usevulkan` (Any GPU), make sure you select the correct .exe with CUDA support.
 - **GPU Layer Offloading**: Add `--gpulayers` to offload model layers to the GPU. The more layers you offload to VRAM, the faster generation speed will become. Experiment to determine number of layers to offload, and reduce by a few if you run out of memory.
 - **Increasing Context Size**: Use `--contextsize (number)` to increase context size, allowing the model to read more text. Note that you may also need to increase the max context in the KoboldAI Lite UI as well (click and edit the number text field).
-- **Old CPU Compatibility**: If you are having crashes or issues, you can try running in a non-avx2 compatibility mode by adding the `--noavx2` flag. You can also try reducing your `--blasbatchssize` (set -1 to avoid batching)
+- **Old CPU Compatibility**: If you are having crashes or issues, you can try running in a non-avx2 compatibility mode by adding the `--noavx2` flag. You can also try reducing your `--blasbatchsize` (set -1 to avoid batching)
 
 For more information, be sure to run the program with the `--help` flag, or **[check the wiki](https://github.com/LostRuins/koboldcpp/wiki).**
 


### PR DESCRIPTION
The README's *Old CPU Compatibility* note (line 79) references `--blasbatchssize` with a doubled `s`.

The actual flag is `--blasbatchsize`, defined in `koboldcpp.py`:

```python
advparser.add_argument("--batchsize","--blasbatchsize","--batch-size","-b", ...)
```

Since argparse only accepts the registered option strings, a user copy-pasting `--blasbatchssize` from the README hits `error: unrecognized arguments`. This one-character fix corrects the flag name so the documented command works.

No functional changes — docs only.