### PR TITLE
fix(api): strip MCP image base64 from tool results in the jinja path (#2374)

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -3466,6 +3466,9 @@ def format_jinja(messages_orig, tools, chat_template_kwargs=None):
         for m in messages:
             if m.get("content") is None:
                 m["content"] = ""
+            # strip mcp image b64 from tool string content so it isn't rendered as text (image is swept out separately)
+            elif m.get("role", "") == "tool" and isinstance(m.get("content"), str):
+                m["content"] = strip_mcpcontent_of_media(m["content"])
         # fix image placeholders, erase them and slap a reference onto the turn text message
         mediacount = 1
         for m in messages:
@@ -3845,6 +3848,10 @@ def sweep_media_from_messages(messages_array):
                     url = item.get("image_url", {}).get("url", "")
                     if url.startswith("data:image"):
                         images.append(url.split(",", 1)[1])
+                elif item.get("type") == "image": #handle mcp image content blocks in a list
+                    data = item.get("data", "")
+                    if data:
+                        images.append(data.split(",", 1)[1] if data.startswith("data:") else data)
                 elif item.get("type") == "input_audio":
                     data = item.get("input_audio", {}).get("data")
                     if data:


### PR DESCRIPTION
### Problem

Fixes #2374. When a tool / MCP result carries an image, the OpenAI-compatible chat adapter's **jinja code path** leaves the base64 payload in the rendered prompt as plain text. As reported, a single 1024×1024 jpeg bloats the context by ~120k tokens. The **legacy (non-jinja) path** already handles this correctly via `strip_mcpcontent_of_media`, so the behavior is inconsistent between the two paths.

There are two related gaps:

1. `format_jinja` never strips the base64 from tool-role **string** content before rendering, so the whole MCP JSON (including the base64) is templated as text.
2. `sweep_media_from_messages` only recognizes `image_url` items inside a content **list**, not MCP-style `image` content blocks (`{"type": "image", "data": ...}`), so images delivered that way are dropped instead of attached.

### Fix

- `format_jinja`: strip the base64 from tool-role string content before rendering (reusing the existing `strip_mcpcontent_of_media`). The image itself is still swept out and attached separately, so nothing is lost — only the multi-KB base64 stops being rendered as text.
- `sweep_media_from_messages`: also recognize `type == "image"` content blocks in a list and attach their `data`.

### Verification

Reproduced both paths with a standalone harness driving the jinja template + sweep logic:

| Scenario | Before | After |
|---|---|---|
| Tool content = MCP JSON **string** with an image | prompt rendered **120,209** chars, base64 inline, 1 image attached | prompt **227** chars, no base64 in text, 1 image attached |
| Tool content = **list** of MCP `image` blocks | 0 images attached (image dropped) | 1 image attached |

Change is 7 added lines, no deletions, and mirrors the existing legacy-path behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
