### PR TITLE
Add Mistral [THINK]/[/THINK] thinking format (mistral3 arch)

### DIFF
--- a/gpttype_adapter.cpp
+++ b/gpttype_adapter.cpp
@@ -5859,6 +5859,11 @@ generation_outputs gpttype_generate(const generation_inputs inputs)
                 end = "<|END_THINKING|>";
                  budget_exceeded = "\n(Reasoning budget exceeded)\nTime to respond now.\n<|END_THINKING|>";
                 break;
+            case llm_arch::LLM_ARCH_MISTRAL3:
+                start = "[THINK]";
+                end = "[/THINK]";
+                budget_exceeded = "\n(Reasoning budget exceeded)\nTime to respond now.\n[/THINK]";
+                break;
             default:
                 break;
         }

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -186,7 +186,8 @@ thinkformats = [{"start":"<|channel|>analysis<|message|>","end":"<|start|>assist
                 {"start":"<think>","end":"</think>"},
                 {"start":"<seed:think>","end":"</seed:think>"},
                 {"start":"<|START_THINKING|>","end":"<|END_THINKING|>"},
-                {"start":"<|channel>thought","end":"<channel|>"}]
+                {"start":"<|channel>thought","end":"<channel|>"},
+                {"start":"[THINK]","end":"[/THINK]"}]
 tool_call_pairs = [ #third element is optional str to match in chat template before we use this pair, fourth element is whether its stream-handleable
     ("<tool_call>", "</tool_call>", None, True), #qwen, glm
     ("<seed:tool_call>", "</seed:tool_call>", None, True), #seed oss


### PR DESCRIPTION
## The defect

`reasoning_effort` is accepted, converted into a token budget and passed all the way down to the
sampler for Mistral models — and then silently dropped. The budget never applies.

`gpttype_adapter.cpp` picks the think delimiters from a `switch` on the model architecture. There is
no `case` for `mistral3`, so it falls back to the default `<think>` / `</think>`. Those are not
vocabulary tokens for Ministral-3, so `TokenizeString` returns more than one token for each, the
`expected_start_tokens` / `expected_end_tokens` guard clears all three vectors, and
`apply_reasoning_budget()` returns at its first `if`.

Nothing is logged. From the client side the parameter looks accepted and simply has no effect.

## The fix

Two independent one-liners, for two separate defects:

- **`case LLM_ARCH_MISTRAL3`** in `gpttype_adapter.cpp` — arms the budget. `[THINK]` and `[/THINK]`
  are single vocabulary tokens (ids 34 and 35 on Ministral-3), so the size guard passes and
  `end_think.size() != 1` — the check inside `apply_reasoning_budget()` — is satisfied too.
- **`{"start":"[THINK]","end":"[/THINK]"}`** in `thinkformats` — without it the thinking block was
  never split out: it leaked into `content` with its `[THINK]` marker still in place, instead of
  going to `reasoning_content`.

## Measurements

`Ministral-3-14B-Reasoning-2512` (IQ4_XS, 41/41 layers, ctx 8192, `--jinja`), 5 real prompts,
**3 samples per cell**, `max_tokens: 3000` — so a 750-token budget at `low`.

Three samples and not one because this model's variance at `temperature 0.7` spans a factor of 4 on
an identical payload; at n=1 an effect cannot be told apart from noise.

Thinking length, in words:

| prompt | before `none` | before `low` | **after `none`** | **after `low`** |
| -- | -- | -- | -- | -- |
| 1 | 777 · 1175 · 2070 | 886 · 1244 · 1894 | **7 · 7 · 7** | **521 · 522 · 533** |
| 2 | 1110 · 1695 · 2094 | 781 · 2058 · 2255 | **7 · 7 · 7** | **527 · 563 · 567** |
| 3 | 445 · 958 · 2136 | 948 · 1198 · 1273 | **7 · 7 · 7** | **555 · 563 · 574** |
| 4 | 311 · 1103 · 2314 | 812 · 930 · 1140 | **7 · 7 · 7** | **229 · 556 · 558** |
| 5 | 345 · 355 · 636 | 340 · 530 · 676 | **7 · 7 · 7** | **339 · 390 · 416** |

Before, the `none` and `low` ranges overlapped cell by cell ([311-2314] vs [340-2255]). After, they
are disjoint: [7-7] and [229-574], and the 750-token ceiling is never exceeded. The 7 words at
`none` are the forced-close phrase itself — with a budget of 0 the thinking is cut at its first
token.

Forced closes (`Reasoning Budget of N tokens exceeded!`): **0/15 before** at `low`, **11/15 after**.
The four unforced ones are samples where the model closed its own thinking before the ceiling.

**No regression on a non-reasoning mistral3 model.** `Ministral-3-8B-Instruct-2512` with
`reasoning_effort: low`: `finish_reason` `stop`, normal 899- and 1181-character answers, no
`reasoning_content`, no `[THINK]` in `content`, **0 forced closes** — `apply_reasoning_budget()`
bails out when the start marker never appears.

## Two questions for you

1. **`LLM_ARCH_MISTRAL4`** (Magistral) likely uses the same markers, but I have no reasoning
   mistral4 GGUF to measure, so I did not add it. Happy to if you prefer.
2. **Would detecting the format from the `chat_template` be a better fit than a per-architecture
   `switch`?** The template is already fetched at the top of that block
   (`chat_template = gpttype_get_chat_template()`) and currently unused, and `tool_call_pairs`
   already does content-based matching via `required_match_txt`. That would also cover
   [#2092](https://github.com/LostRuins/koboldcpp/issues/2092) (Gemma4 think tags not detected),
   which looks like the same defect in another format. I kept this PR to the minimal, measured
   change rather than reworking a path that affects every reasoning model — happy to follow your
   preference.