### PR TITLE
fix(router): don't let an unmatched model field block autoswap (#2384)

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -4403,11 +4403,11 @@ class KcppProxyHandler(http.server.BaseHTTPRequestHandler):
                     is_different_model = True
 
                 if is_different_model or was_auto_unloaded:
-                    model_switch_pass = True
                     whitelist = get_current_admindir_list() # see if its an allowed swap
                     if was_auto_unloaded and not model_name:
                         model_name = "initial_model"
                     if is_different_model and (model_name in whitelist):
+                        model_switch_pass = True # only claim the request if we really are swapping
                         global_memory["last_active_timestamp"] = datetime.now()
                         global_memory["triggered_sleeping"] = False
                         reqbody = json.dumps({"filename":model_name})


### PR DESCRIPTION
Fixes #2384.

## The bug

In the router proxy's `_handle`, a POST to `/v1/completions` or `/v1/chat/completions` enters the explicit model-swap branch. That branch sets `model_switch_pass = True` *before* it checks whether the requested name is actually a swappable config:

```python
if is_different_model or was_auto_unloaded:
    model_switch_pass = True
    whitelist = get_current_admindir_list()
    ...
    if is_different_model and (model_name in whitelist):
        ...issue /api/admin/reload_config...
```

When the client sends a `model` name that is not an entry in the admin dir — which is the normal case for OpenAI-compatible clients that just send their configured model string — the whitelist check fails and no reload is issued. But the flag has already been set, so the autoswap dispatch immediately below is skipped:

```python
if autoswapEnabled and not model_switch_pass:
    # decides text/stt/tts/embed/music/image and reloads for that type
```

Nothing loads the text model, and the request is forwarded upstream to a server with no model. That is the reported `finish_reason:"error"`, `prompt_tokens:0`, on every request rather than just the first.

This also explains the two things the report singles out:

- **Only chat/completions is affected.** `/v1/embeddings`, `/v1/audio/speech` and `/v1/audio/transcriptions` are not `is_completions_path`/`is_chat_completions_path`, and with autoswap on, `(not autoswapEnabled and is_wake_request)` is false — so they never enter the branch, `model_switch_pass` stays `False`, and autoswap loads them on demand.
- **Sending one request with an empty/absent `model` works around it.** Empty name → `is_different_model` is false → flag stays `False` → autoswap runs.

And the follow-up comment about `adminunloadtimeout`: in autoswap mode the unload timeout parks `swapReqType` at `"nomodel"`, and recovery from that state is done by the very dispatch this flag suppresses — so the same wedge returns after every idle unload.

## The fix

Set `model_switch_pass` only on the path that actually issues the reload. One line moved.

`model_switch_pass` is read in exactly one place, guarded by `autoswapEnabled`, so this is a no-op when autoswap is off.

## Verification

I extracted the decision region from `koboldcpp.py` verbatim (from `autoswapEnabled = global_memory[...]` down to `try:  # connect upstream`) and executed it under stubs for the upstream connection and `get_current_admindir_list`, so the real branch logic runs rather than a paraphrase of it. Nine scenarios, run against the file before and after the change:

| Scenario | before | after |
|---|---|---|
| cold + chat + `model` not a config name | **no reload, `swapReqType` stays `None`** | reload, `swapReqType="text"` |
| after `adminunloadtimeout` + chat + `model` field | **no reload, stuck at `"nomodel"`** | reload, `swapReqType="text"` |
| cold + chat + no `model` field (the workaround) | reload, `"text"` | same |
| cold + `/v1/embeddings` + `model` field | reload, `"embed"` | same |
| cold + chat + `model` **is** a whitelisted config | reload of that config | same |
| steady state, text already loaded | no reload | same |
| `/v1/audio/speech` after text | reload, `"tts"` | same |
| autoswap off + chat + whitelisted `model` | reload of that config | same |
| autoswap off + auto-unloaded + chat, no `model` | no reload | same |

The two failing rows are exactly the ones in the report, and they land on the same behaviour as the model-less request that is known to work. The other seven are byte-identical.

Branched from the fork's `concedo` because syncing it needs `workflow` scope, which this token does not have. The block being changed is identical in both revisions, and the diff is the one hunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
