### PR TITLE
sd: set step as 0 for the first noisy preview

### DIFF
--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -1787,7 +1787,7 @@ static void step_callback(int step, int frame_count, sd_image_t* image, bool is_
                 set_preview_images(0);
             }
         }
-        geninfo.gendata.step = step;
+        geninfo.gendata.step = is_noisy ? 0 : step;
         geninfo.gendata.step_time = step_time;
         should_encode_preview = !is_noisy && geninfo.preview_enabled;
     }


### PR DESCRIPTION
The initial noisy preview is reported before denoising, so it shows the ongoing step number; but we immediately switch to denoised previews or progress callback info, which instead show concluded steps. So we currently report step '1' during the first two inference steps.