### PR TITLE
sd: avoid race condition when testing genkey for preview

### DIFF
--- a/expose.cpp
+++ b/expose.cpp
@@ -217,13 +217,13 @@ extern "C"
     {
         sdtype_abort_generation();
     }
-    sd_info_outputs sd_get_ongoing_generation_info()
+    sd_info_outputs sd_get_ongoing_generation_info(const char* genkey)
     {
-        return sdtype_get_ongoing_generation_info();
+        return sdtype_get_ongoing_generation_info(genkey);
     }
-    void sd_request_ongoing_generation_preview()
+    void sd_request_ongoing_generation_preview(const char* genkey)
     {
-        sdtype_request_ongoing_generation_preview();
+        sdtype_request_ongoing_generation_preview(genkey);
     }
 
     bool whisper_load_model(const whisper_load_model_inputs inputs)

--- a/expose.h
+++ b/expose.h
@@ -256,6 +256,7 @@ struct sd_generation_inputs
     const int lora_len = 0;
     const char ** lora_filenames = nullptr;
     const float * lora_multipliers = nullptr;
+    const char * genkey = nullptr;
 };
 struct sd_generation_outputs
 {

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -100,7 +100,6 @@ mmprojName = None
 lastgeneratedcomfyimg = b''
 lastgeneratedcachedimg = b''
 lastgeneratedcachedimgkey = b''
-currgenimgkey = ''
 lastuploadedcomfyimg = b''
 fullsdmodelpath = ""  #if empty, it's not initialized
 password = "" #if empty, no auth key required
@@ -492,7 +491,8 @@ class sd_generation_inputs(ctypes.Structure):
                 ("upscale", ctypes.c_bool),
                 ("lora_len", ctypes.c_int),
                 ("lora_filenames", ctypes.POINTER(ctypes.c_char_p)),
-                ("lora_multipliers", ctypes.POINTER(ctypes.c_float))]
+                ("lora_multipliers", ctypes.POINTER(ctypes.c_float)),
+                ("genkey", ctypes.c_char_p)]
 
 class sd_generation_outputs(ctypes.Structure):
     _fields_ = [("status", ctypes.c_int),
@@ -1044,9 +1044,9 @@ def init_library():
     handle.sd_get_info.restype = sd_info_outputs
     handle.sd_abort_generation.argtypes = []
     handle.sd_abort_generation.restype = None
-    handle.sd_get_ongoing_generation_info.argtypes = []
+    handle.sd_get_ongoing_generation_info.argtypes = [ctypes.c_char_p]
     handle.sd_get_ongoing_generation_info.restype = sd_info_outputs
-    handle.sd_request_ongoing_generation_preview.argtypes = []
+    handle.sd_request_ongoing_generation_preview.argtypes = [ctypes.c_char_p]
     handle.sd_request_ongoing_generation_preview.restype = None
     handle.whisper_load_model.argtypes = [whisper_load_model_inputs]
     handle.whisper_load_model.restype = ctypes.c_bool
@@ -2902,6 +2902,7 @@ def lora_map_name_to_path(request_list):
 def sd_generate(genparams):
     global maxctx, args, currentusergenkey, totalgens, pendingabortkey, chatcompl_adapter
 
+    genkey = genparams.get('genkey', '')
     job_timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
 
     default_adapter = {} if chatcompl_adapter is None else chatcompl_adapter
@@ -3020,6 +3021,7 @@ def sd_generate(genparams):
     inputs.lora_len = len(lora_filenames)
     inputs.lora_filenames = (ctypes.c_char_p * inputs.lora_len)(*lora_filenames)
     inputs.lora_multipliers = (ctypes.c_float * inputs.lora_len)(*lora_multipliers)
+    inputs.genkey = (genkey or "").encode("UTF-8")
 
     ret = handle.sd_generate(inputs)
     data_main = ""
@@ -3036,8 +3038,8 @@ def sd_generate(genparams):
     info["job_timestamp"] = job_timestamp
     return {"animated": animated, "data":data_main, "data_extra":data_extra, "final_frame":final_frame, "info": info}
 
-def sd_get_ongoing_generation_info():
-    info = handle.sd_get_ongoing_generation_info()
+def sd_get_ongoing_generation_info(genkey):
+    info = handle.sd_get_ongoing_generation_info(genkey)
     if info.status == 0:
         try:
             return json.loads(info.data)
@@ -3138,10 +3140,11 @@ def build_a1111_progress_response(
         "textinfo": textinfo
     }
 
-def a1111_progress_response(preview=False):
+def a1111_progress_response(preview=False, genkey=None):
+    genkey = (genkey or "").encode("UTF-8")
     if preview:
-        handle.sd_request_ongoing_generation_preview()
-    status = sd_get_ongoing_generation_info()
+        handle.sd_request_ongoing_generation_preview(genkey)
+    status = sd_get_ongoing_generation_info(genkey)
     result = build_a1111_progress_response(
         status.get('status', 0),
         status.get('step', 0),
@@ -6489,7 +6492,7 @@ Change Mode<br>
     def do_GET(self):
         global embedded_kailite, embedded_kcpp_docs, embedded_kcpp_sdui, embedded_kailite_gz, embedded_kcpp_docs_gz, embedded_kcpp_sdui_gz, embedded_lcpp_ui_gz, embedded_musicui, embedded_musicui_gz
         global last_req_time, start_time, cached_chat_template, cached_sd_info, has_vision_support, has_audio_support, has_whisper, friendlymodelname
-        global savedata_obj, has_multiplayer, multiplayer_turn_major, multiplayer_turn_minor, multiplayer_story_data_compressed, multiplayer_dataformat, multiplayer_lastactive, maxctx, maxhordelen, friendlymodelname, lastuploadedcomfyimg, lastgeneratedcomfyimg, lastgeneratedcachedimg, lastgeneratedcachedimgkey, currgenimgkey, KcppVersion, totalgens, preloaded_story, exitcounter, currentusergenkey, friendlysdmodelname, fullsdmodelpath, password, friendlyembeddingsmodelname, voicelist
+        global savedata_obj, has_multiplayer, multiplayer_turn_major, multiplayer_turn_minor, multiplayer_story_data_compressed, multiplayer_dataformat, multiplayer_lastactive, maxctx, maxhordelen, friendlymodelname, lastuploadedcomfyimg, lastgeneratedcomfyimg, lastgeneratedcachedimg, lastgeneratedcachedimgkey, KcppVersion, totalgens, preloaded_story, exitcounter, currentusergenkey, friendlysdmodelname, fullsdmodelpath, password, friendlyembeddingsmodelname, voicelist
         global autoswapmode, textName, sttName, ttsName, embedName, musicName, imageName, mmprojName
 
         clean_path = self.path.split("?")[0] #for cases where we do not want query params
@@ -6754,9 +6757,7 @@ Change Mode<br>
             parsed_dict = urllib.parse.parse_qs(parsed_url.query)
             genkey = parsed_dict.get('genkey', [''])[0]
             skip_current_image = parse_query_bool(parsed_dict, 'skip_current_image')
-            # with no auth, reveal status without preview image
-            auth = bool(genkey and genkey==currgenimgkey)
-            info = a1111_progress_response(auth and not skip_current_image)
+            info = a1111_progress_response(not skip_current_image, genkey)
             response_body = json.dumps(info).encode()
         elif clean_path=='/history' or clean_path=='/api/history' or clean_path.startswith('/api/history/') or clean_path.startswith('/history/'): #emulate comfyui
             modelNameToReturn = friendlysdmodelname
@@ -6893,7 +6894,7 @@ Change Mode<br>
 
     def do_POST(self):
         global thinkformats
-        global modelbusy, batched_request_runner_count, requestsinqueue, currentusergenkey, totalgens, pendingabortkey, lastuploadedcomfyimg, lastgeneratedcomfyimg, lastgeneratedcachedimg, lastgeneratedcachedimgkey, currgenimgkey, multiplayer_turn_major, multiplayer_turn_minor, multiplayer_story_data_compressed, multiplayer_dataformat, multiplayer_lastactive, net_save_slots, has_vision_support, savestate_limit, mcp_lock
+        global modelbusy, batched_request_runner_count, requestsinqueue, currentusergenkey, totalgens, pendingabortkey, lastuploadedcomfyimg, lastgeneratedcomfyimg, lastgeneratedcachedimg, lastgeneratedcachedimgkey, multiplayer_turn_major, multiplayer_turn_minor, multiplayer_story_data_compressed, multiplayer_dataformat, multiplayer_lastactive, net_save_slots, has_vision_support, savestate_limit, mcp_lock
         global autoswapmode, textName, sttName, ttsName, embedName, musicName, imageName, mmprojName
         contlenstr = self.headers['content-length']
         content_length = 0
@@ -7862,7 +7863,6 @@ Change Mode<br>
                     try:
                         lastgeneratedcachedimg = b''
                         lastgeneratedcachedimgkey = ''
-                        currgenimgkey = genparams.get('genkey', '')
                         if is_comfyui_imggen:
                             lastgeneratedcomfyimg = b''
                             genparams = sd_comfyui_tranform_params(genparams)
@@ -7886,7 +7886,6 @@ Change Mode<br>
                         gendatextra = gen["data_extra"]
                         genfinalframe = gen["final_frame"]
                         geninfo = json.dumps(gen["info"]) # sdapi really expects a stringified JSON
-                        currgenimgkey = ''
                         genresp = None
                         if gendat:
                             lastgeneratedcachedimg = base64.b64decode(gendat)
@@ -7909,7 +7908,6 @@ Change Mode<br>
                         self.end_headers(content_type='application/json')
                         self.wfile.write(genresp)
                     except Exception as ex:
-                        currgenimgkey = ''
                         utfprint(ex,1)
                         print("Generate Image: The response could not be sent, maybe connection was terminated?")
                         time.sleep(0.2) #short delay

--- a/model_adapter.h
+++ b/model_adapter.h
@@ -112,8 +112,8 @@ bool sdtype_load_model(const sd_load_model_inputs inputs);
 sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs);
 sd_generation_outputs sdtype_upscale(const sd_upscale_inputs inputs);
 sd_info_outputs sdtype_get_info();
-sd_info_outputs sdtype_get_ongoing_generation_info();
-void sdtype_request_ongoing_generation_preview();
+sd_info_outputs sdtype_get_ongoing_generation_info(const char* genkey);
+void sdtype_request_ongoing_generation_preview(const char* genkey);
 void sdtype_abort_generation();
 
 bool whispertype_load_model(const whisper_load_model_inputs inputs);

--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -1787,7 +1787,7 @@ static void step_callback(int step, int frame_count, sd_image_t* image, bool is_
                 set_preview_images(0);
             }
         }
-        geninfo.gendata.step = step;
+        geninfo.gendata.step = is_noisy ? 0 : step;
         geninfo.gendata.step_time = step_time;
         should_encode_preview = !is_noisy && geninfo.preview_enabled;
     }

--- a/otherarch/sdcpp/sdtype_adapter.cpp
+++ b/otherarch/sdcpp/sdtype_adapter.cpp
@@ -167,14 +167,38 @@ struct gendata_st {
     std::string preview;
 };
 
-struct {
-    std::mutex mux;
+struct genstatus_st {
+    std::string genkey;
     std::chrono::steady_clock::time_point start_time;
     int steps = 0;
     bool preview_requested = false;
     bool preview_enabled = false;
     gendata_st gendata;
+};
+
+static constexpr size_t max_genstatus = 2;
+
+static struct {
+    std::mutex mux;
+    genstatus_st genstatus[max_genstatus];
+    size_t next_slot = 0;
+    size_t active_slot = max_genstatus;
 } geninfo;
+
+static genstatus_st* get_preview_data(const std::string& genkey = "") {
+    if (genkey == "") {
+        if (geninfo.active_slot != max_genstatus) {
+            return &geninfo.genstatus[geninfo.active_slot];
+        }
+    } else {
+        for (auto& record: geninfo.genstatus) {
+            if (record.genkey == genkey) {
+                return &record;
+            }
+        }
+    }
+    return nullptr;
+}
 
 static struct {
     std::string data;
@@ -313,24 +337,27 @@ static void progress_callback(int step, int steps, float time, void* data)
     const char* phase = "Encoding";
     {
         std::lock_guard<std::mutex> lock(geninfo.mux);
-        if (geninfo.gendata.status == 2 && geninfo.preview_requested && !geninfo.preview_enabled) {
-            geninfo.preview_enabled = true;
+        auto active = get_preview_data();
+        if (!active) return;
+
+        if (active->gendata.status == 2 && active->preview_requested && !active->preview_enabled) {
+            active->preview_enabled = true;
             set_preview_images(2);
         }
         /* Once diffusion has started, use progress_callback for step counts
         because img2img and custom schedules can change the effective total. */
-        if (geninfo.gendata.status == 2) {
+        if (active->gendata.status == 2) {
             /* adjust the max step count (may change for img2img) */
-            geninfo.steps = steps;
-            if (step != geninfo.gendata.step) {
-                geninfo.gendata.step = step;
-                geninfo.gendata.preview = "";
+            active->steps = steps;
+            if (step != active->gendata.step) {
+                active->gendata.step = step;
+                active->gendata.preview = "";
             }
             if (step == steps) {
-                geninfo.gendata.status = 3;
+                active->gendata.status = 3;
             }
             phase = "Generating image";
-        } else if (geninfo.gendata.status == 3) {
+        } else if (active->gendata.status == 3) {
             phase = "Decoding";
         }
         /* let the terminal report tiling progress */
@@ -1069,13 +1096,21 @@ void sdtype_abort_generation() {
 
 sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
 {
+    std::string genkey = inputs.genkey ? inputs.genkey : "";
+
     struct CleanupInfoOnExit {
         ~CleanupInfoOnExit() {
             {
                 std::lock_guard<std::mutex> lock(geninfo.mux);
-                geninfo.gendata.status = 0;
-                geninfo.preview_requested = false;
-                geninfo.preview_enabled = false;
+                size_t status_slot = geninfo.active_slot;
+                if (status_slot < max_genstatus) {
+                    auto& genstatus = geninfo.genstatus[status_slot];
+                    genstatus.gendata.status = 0;
+                    genstatus.gendata.preview = "";
+                    genstatus.preview_requested = false;
+                    genstatus.preview_enabled = false;
+                }
+                geninfo.active_slot = max_genstatus;
             }
             set_preview_images(0);
         }
@@ -1088,12 +1123,17 @@ sd_generation_outputs sdtype_generate(const sd_generation_inputs inputs)
 
     {
         std::lock_guard<std::mutex> lock(geninfo.mux);
-        geninfo.start_time = std::chrono::steady_clock::now();
-        geninfo.steps = inputs.sample_steps;
-        geninfo.preview_requested = false;
-        geninfo.preview_enabled = false;
-        geninfo.gendata = {};
-        geninfo.gendata.status = 1;
+        size_t status_slot = geninfo.next_slot;
+        geninfo.next_slot = (status_slot + 1) % max_genstatus;
+        geninfo.active_slot = status_slot;
+        auto& genstatus = geninfo.genstatus[status_slot];
+        genstatus.genkey = genkey;
+        genstatus.start_time = std::chrono::steady_clock::now();
+        genstatus.steps = inputs.sample_steps;
+        genstatus.preview_requested = false;
+        genstatus.preview_enabled = false;
+        genstatus.gendata = {};
+        genstatus.gendata.status = 1;
         set_preview_images(1);
     }
 
@@ -1774,23 +1814,25 @@ static void step_callback(int step, int frame_count, sd_image_t* image, bool is_
 {
     step = step < 0 ? -step : step;
     std::lock_guard<std::mutex> lock(geninfo.mux);
-    double step_time = get_time_delta(geninfo.start_time);
+
+    auto active = get_preview_data();
+    if (!active) return;
+
+    double step_time = get_time_delta(active->start_time);
 
     bool should_encode_preview = false;
-    {
-        if (geninfo.gendata.status <= 1) {
-            geninfo.gendata.status = 2;
-            if (geninfo.preview_requested && !geninfo.preview_enabled) {
-                geninfo.preview_enabled = true;
-                set_preview_images(2);
-            } else {
-                set_preview_images(0);
-            }
+    if (active->gendata.status <= 1) {
+        active->gendata.status = 2;
+        if (active->preview_requested && !active->preview_enabled) {
+            active->preview_enabled = true;
+            set_preview_images(2);
+        } else {
+            set_preview_images(0);
         }
-        geninfo.gendata.step = is_noisy ? 0 : step;
-        geninfo.gendata.step_time = step_time;
-        should_encode_preview = !is_noisy && geninfo.preview_enabled;
     }
+    active->gendata.step = is_noisy ? 0 : step;
+    active->gendata.step_time = step_time;
+    should_encode_preview = !is_noisy && active->preview_enabled;
 
     if (!should_encode_preview) {
         return;
@@ -1813,17 +1855,20 @@ static void step_callback(int step, int frame_count, sd_image_t* image, bool is_
     }
 
     {
-        geninfo.gendata.step = step;
-        geninfo.gendata.step_time = step_time;
-        geninfo.gendata.preview = preview;
+        active->gendata.step = step;
+        active->gendata.step_time = step_time;
+        active->gendata.preview = preview;
     }
 }
 
-void sdtype_request_ongoing_generation_preview()
+void sdtype_request_ongoing_generation_preview(const char* genkey)
 {
+    if (!genkey || !*genkey) return;
     std::lock_guard<std::mutex> lock(geninfo.mux);
-    if (geninfo.gendata.status != 0 && !geninfo.preview_requested) {
-        geninfo.preview_requested = true;
+    auto active = get_preview_data(genkey);
+    if (!active) return;
+    if (active->gendata.status != 0 && !active->preview_requested) {
+        active->preview_requested = true;
     }
 }
 
@@ -1919,17 +1964,32 @@ sd_info_outputs sdtype_get_info()
     return output;
 }
 
-sd_info_outputs sdtype_get_ongoing_generation_info()
+sd_info_outputs sdtype_get_ongoing_generation_info(const char* genkey)
 {
     double elapsed_time = 0.0;
     int steps = 0;
-    gendata_st gendata;
+    gendata_st gendata = {};
+    std::string key = genkey ? genkey : "";
+
     {
         std::lock_guard<std::mutex> lock(geninfo.mux);
-        gendata = geninfo.gendata;
-        steps = geninfo.steps;
-        if (gendata.status != 0) {
-            elapsed_time = get_time_delta(geninfo.start_time);
+        genstatus_st* record = nullptr;
+        if (!key.empty()) {
+            record = get_preview_data(key);
+        }
+        if (record) {
+            elapsed_time = get_time_delta(record->start_time);
+            steps = record->steps;
+            gendata = record->gendata;
+        } else {
+            // no key: retrieve current status, no preview
+            record = get_preview_data();
+            if (record) {
+                elapsed_time = get_time_delta(record->start_time);
+                steps = record->steps;
+                gendata = record->gendata;
+                gendata.preview = "";
+            }
         }
     }
 
@@ -1950,7 +2010,7 @@ sd_info_outputs sdtype_get_ongoing_generation_info()
         j["status"] = "UNKNOWN";
     j["preview"] = gendata.preview;
 
-    static thread_local std::string recent_info;
+    static std::string recent_info;
     recent_info = j.dump();
     sd_info_outputs output;
     output.status = 0;


### PR DESCRIPTION
Moves `genkey` checking to the C++ layer, to avoid things like an abort immediately followed by a new gen retrieving the preview from the aborted gen.

On top of #2416 ; if you think both are OK it's probably easier to just merge this one.