### PR TITLE
Linux downgrade to CUDA11.4

### DIFF
--- a/.github/workflows/kcpp-build-release-linux-oldpc.yaml
+++ b/.github/workflows/kcpp-build-release-linux-oldpc.yaml
@@ -10,9 +10,9 @@ on:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  LLAMA_NOAVX2: 1
-  LLAMA_ARCHES_CU11: 1
-  KCPP_CUDA: 11.5.0
+  NOAVX2: 1
+  ARCHES_CU11: 1
+  KCPP_CUDA: 11.4.0
 
 jobs:
   linux:

--- a/.github/workflows/kcpp-build-release-linux-oldpc.yaml
+++ b/.github/workflows/kcpp-build-release-linux-oldpc.yaml
@@ -10,8 +10,8 @@ on:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  NOAVX2: 1
-  ARCHES_CU11: 1
+  LLAMA_NOAVX2: 1
+  LLAMA_ARCHES_CU11: 1
   KCPP_CUDA: 11.5.0
 
 jobs:

--- a/.github/workflows/kcpp-build-release-linux-oldpc.yaml
+++ b/.github/workflows/kcpp-build-release-linux-oldpc.yaml
@@ -54,7 +54,7 @@ jobs:
           ./koboldcpp.sh dist
 
       - name: Rename file before upload
-        run: mv dist/koboldcpp-linux-x64-cuda1150 dist/koboldcpp-linux-x64-oldpc
+        run: mv dist/koboldcpp-linux-x64-cuda1140 dist/koboldcpp-linux-x64-oldpc
 
       - name: Save artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test-unofficial-linux-olderpc.yaml
+++ b/.github/workflows/test-unofficial-linux-olderpc.yaml
@@ -12,7 +12,7 @@ env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   NOAVX1: 1
   ARCHES_CU11: 1
-  KCPP_CUDA: 11.5.0
+  KCPP_CUDA: 11.4.0
 
 jobs:
   linux:
@@ -53,7 +53,7 @@ jobs:
           ./koboldcpp.sh dist
 
       - name: Rename file before upload
-        run: mv dist/koboldcpp-linux-x64-cuda1150 dist/koboldcpp-linux-x64-olderpc
+        run: mv dist/koboldcpp-linux-x64-cuda1140 dist/koboldcpp-linux-x64-olderpc
 
       - name: Save artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
Can't believe it took this long for someone to notice and report it to us, but the CI configures the env variables wrong producing fake linux oldpc builds. This fixes it.