### PR TITLE
Fix two memoization bugs in llama_grammar_reject_candidates_for_stack

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -1114,9 +1114,24 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
     if (candidates_hash_size < hash_cutoff) {
         // Only check stash hash first - these are usually ~24b, and almost always under 64b
         if (auto cache_hit = memo_cache.find(stack_hash); cache_hit != memo_cache.end()) {
-            auto & candidates_memos      = cache_hit->second;
-            auto   candidates_hash_start = reinterpret_cast<const char *>(candidates.data());
-            auto   candidates_hash       = std::hash<bytes>{}({ candidates_hash_start, candidates_hash_size });
+            auto & candidates_memos = cache_hit->second;
+            // Hash candidate content (index, id, partial_utf8, decoded code_points sequence)
+            // rather than raw struct bytes, which include the code_points pointer value.
+            // Pointer values can be reused by the allocator across calls pointing to different
+            // content, causing false cache hits that return stale reject sets.
+            size_t candidates_hash = candidates.size();
+            auto combine = [&](size_t v) {
+                candidates_hash ^= v + 0x9e3779b9 + (candidates_hash << 6) + (candidates_hash >> 2);
+            };
+            for (const auto & c : candidates) {
+                combine(std::hash<size_t>{}(c.index));
+                combine(std::hash<llama_token>{}(c.id));
+                combine(std::hash<uint32_t>{}(c.partial_utf8.value));
+                combine(std::hash<int>{}(c.partial_utf8.n_remain));
+                for (const uint32_t * cp = c.code_points; *cp != 0; ++cp) {
+                    combine(std::hash<uint32_t>{}(*cp));
+                }
+            }
             if (auto cache_hit2 = candidates_memos.find(candidates_hash); cache_hit2 != candidates_memos.end()) {
                 return cache_hit2->second;
             } else {
@@ -1141,6 +1156,11 @@ llama_grammar_candidates llama_grammar_reject_candidates_for_stack(
             } else if (!llama_grammar_match_token(stack_pos, tok.id)) {
                 rejects.push_back(tok);
             }
+        }
+        // cache_target was set by operator[] which pre-inserted an empty vector; write the
+        // result here so subsequent lookups don't return an empty reject set.
+        if (cache_target) {
+            *cache_target = rejects;
         }
         return rejects;
     }


### PR DESCRIPTION
## Summary

Two bugs in the grammar memoization cache introduced by PR #1615.

### Bug 1: TOKEN/TOKEN_NOT branch leaves empty reject set in cache

`operator[]` at the cache-insert site (inside the `candidates_hash_size < hash_cutoff` block) pre-inserts an empty `llama_grammar_candidates` vector and sets `cache_target`. The `TOKEN`/`TOKEN_NOT` rule branch computed its rejects correctly but returned early without writing them to `*cache_target`. On the next call with the same `(stack_hash, candidates_hash)`, the lookup finds the pre-inserted empty vector and returns it — reporting "reject nothing" for what should be a non-empty reject set. This causes grammar-invalid tokens to pass through, corrupting grammar state on the subsequent `llama_grammar_accept_impl` call.

**Fix:** write `*cache_target = rejects` before the early return in the `TOKEN`/`TOKEN_NOT` branch.

### Bug 2: Candidate key hashed over raw struct bytes including pointer value

The candidate list was hashed as raw struct bytes, which include the `code_points` field — a `const uint32_t *` pointer to heap-allocated decoded token data. The allocator can reuse the same heap address across calls pointing to different content, causing a false cache hit that returns a stale reject set for a different candidate list.

**Fix:** hash actual content (`index`, `id`, `partial_utf8.value`, `partial_utf8.n_remain`, and the sequence of `uint32_t` values pointed to by `code_points`) rather than raw struct bytes.

## Test plan

- [ ] Build with `make` and run a generation with a complex JSON grammar to exercise the TOKEN rule path
- [ ] Verify generation speed is unchanged from post-#1615 baseline on simple grammars
- [ ] Verify no grammar constraint violations on a grammar with TOKEN/TOKEN_NOT rules (e.g. tool-call grammars)